### PR TITLE
The energy of the ground state of the Phi basis is no longer set to 0…

### DIFF
--- a/src/libra_py/acf_matrix.py
+++ b/src/libra_py/acf_matrix.py
@@ -73,9 +73,11 @@ def acf(data,dt):
     dt - (float) - time distance between the adjacent data points
     """
 
-    sz = len(data)/2  # how many elements we have in the time series
-                      # we use only a half of the point, because of the 
-                      # poorer statistics we get otherwise
+    sz = len(data)    # For now, we will use the full data set 
+
+                      ###               how many elements we have in the time series
+                      ###  old comments we use only a half of the point, because of the 
+                      ###               poorer statistics we get otherwise
     autocorr = []
     ndof = data[0].num_of_rows
 

--- a/src/libra_py/workflows/nbra/mapping.py
+++ b/src/libra_py/workflows/nbra/mapping.py
@@ -45,7 +45,7 @@ def energy_mat_arb(SD, e, dE):
     n = len(SD)
     E = CMATRIX(n,n)
   
-    E0 = energy_arb(SD[0], e) + dE[0]*(1.0+0.0j)
+    E0 = 0.0 #energy_arb(SD[0], e) + dE[0]*(1.0+0.0j)
     for i in xrange(n):
         E.set(i,i, energy_arb(SD[i], e) + dE[i]*(1.0+0.0j) - E0 )
 

--- a/src/libra_py/workflows/nbra/step4.py
+++ b/src/libra_py/workflows/nbra/step4.py
@@ -157,16 +157,25 @@ def transform_data(X, params):
     default_params = { "shift1":sh1, "shift2":sh2, "scale":scl  }
     comn.check_input(params, default_params, critical_params)
 
+    #print "Before shifting / scaling = "
+    #X[0][0].show_matrix()
+    #print "shift1 = "
+    #params["shift1"].show_matrix()
+    #print "scale = "
+    #params["scale"].show_matrix()
+
     for idata in xrange(ndata):
         for istep in xrange(nsteps):
 
             tmp = CMATRIX(X[idata][istep])
             tmp = tmp + params["shift1"]
-            tmp.dot_product( tmp, params["scale"] )
+            tmp.dot_product( tmp, params["scale"].H() )
             tmp = tmp + params["shift2"]
             X[idata][istep] = CMATRIX(tmp)
 
-
+    #print "After shifting / scaling = "
+    #X[0][0].show_matrix()
+    #sys.exit(0)
 
 
 def traj_statistics(i, Coeff, istate, Hvib, itimes):


### PR DESCRIPTION
….0. Normalization constants for the Chi basis are now computed based on SD overlaps. For the first of the two schemes for the computation of the autocorrelation function, the full data set provided by the user is now utilized.