### PR TITLE
Update readme, conda install, wrong channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ First let's install the most general packages:
 
     conda install -y -c conda-forge numpy scipy matplotlib imageio jupyter_core
     conda install -y ipykernel
-    conda install -y -c rgm py3dmol
+    conda install -y -c rmg py3dmol
 
 
 Next, all what we actually need:


### PR DESCRIPTION
Upon copy pasting this into my terminal, I received a package could not be found error. I searched anaconda and found an extremely similarly named channel, with just 2 characters transposed. https://anaconda.org/rmg/py3dmol

Sincere apologies if I've done this wrong, this is my first contribution here.