### PR TITLE
updates for MASH sampling

### DIFF
--- a/src/dyn/dyn_variables_electronic.cpp
+++ b/src/dyn/dyn_variables_electronic.cpp
@@ -306,6 +306,9 @@ void dyn_variables::init_amplitudes(bp::dict _params, Random& rnd){
                     their phases are set to exp(-2*pi*i*rnd), where rnd is a random 
                     number uniformly distributed on the [0, 1] interval (line in option 1)
 
+                - 4 : initialize all states according to Voronoi-style sampling 
+                    Designed for MASH dynamics
+
             * **params["nstates"]** ( int ): the number of electronic states in the basis
                 [ default: 1 ]
 
@@ -390,9 +393,9 @@ void dyn_variables::init_amplitudes(bp::dict _params, Random& rnd){
            the rep = "<<rep<<" is not known. Allowed values are: [0, 1]\n";
   }
 
-  if(! (init_type==0 || init_type==1 || init_type==2 || init_type==3)){
+  if(! (init_type==0 || init_type==1 || init_type==2 || init_type==3 || init_type==4)){
     cout<<"WARNINIG in init_amplitudes:\
-           the init_type = "<<init_type<<" is not known. Allowed values are: [0, 1, 2, 3]\n";
+           the init_type = "<<init_type<<" is not known. Allowed values are: [0, 1, 2, 3, 4]\n";
   }
   
   if(init_type==0 || init_type==1){
@@ -485,7 +488,27 @@ void dyn_variables::init_amplitudes(bp::dict _params, Random& rnd){
           else if(rep==1){ ampl_adi->set(i, traj, ampl);  }
       }
 
-    }// init_type==2
+    }// init_type==3
+
+    else if(init_type==4){
+      if(verbosity > 0){
+        cout<<"======= Initialization type is "<<init_type<<" ========\n";
+        cout<<"setting representation "<<rep<<" coefficients C_i for all i to complex numbers such that populations are sampled evenly \n";
+      }
+
+      istates = rnd.voron(istates.size(), istate);
+      for(i=0; i<istates.size(); i++){
+        cout<<"Voron_mag["<<i<<"]= "<<istates[i]<<endl;
+        ksi = rnd.uniform(0.0, 1.0);
+        complex<double> ampl(cos(2.0*M_PI*ksi), sin(2.0*M_PI*ksi) );
+        ampl = ampl * sqrt( istates[i] );
+        cout<<"Voron_amp["<<i<<"]= "<<ampl<<endl;
+
+        if(rep==0){ ampl_dia->set(i, traj, ampl );  }
+        else if(rep==1){ ampl_adi->set(i, traj, ampl);  }
+      }
+    }
+
   }// for traj
 
   if(verbosity > 1){

--- a/src/libra_py/dynamics/tsh/compute.py
+++ b/src/libra_py/dynamics/tsh/compute.py
@@ -765,7 +765,7 @@ def generic_recipe(_dyn_params, compute_model, _model_params,_init_elec, _init_n
 
     comn.check_input( model_params, {  }, [ "model0" ] )
     comn.check_input( dyn_params, { "rep_tdse":1, "is_nbra":0, "ntraj":1 }, [  ] )
-    comn.check_input( init_nucl, {"init_type":3, "ndof":1, "q":[0.0], "p":[0.0], "mass":[2000.0], "force_constant":[0.01] }, [] )
+    comn.check_input( init_nucl, {"init_type":3, "ndof":1, "q":[0.0], "p":[0.0], "mass":[2000.0], "force_constant":[0.01], "q_width":[1.0], "p_width":[1.0] }, [] )
 
 
     is_nbra =  dyn_params["isNBRA"]

--- a/src/math_random/librandom.cpp
+++ b/src/math_random/librandom.cpp
@@ -59,6 +59,7 @@ void export_Random_objects(){
       .def("poiss2",&Random::poiss2)
       .def("p_poiss",&Random::p_poiss)
 
+      .def("voron",&Random::voron)
 
   // Poisson distribution
 //  int poiss(double lambda,double t);

--- a/src/math_random/random.cpp
+++ b/src/math_random/random.cpp
@@ -387,6 +387,38 @@ double Random::p_poiss(int k,double lambda){
   return res;  
 }
 
+//============================================================
+//    Even Samples from Voronoi Tessellation-like regions
+vector<double> Random::voron(int nstates, int active_state){
+  vector<double> cuts(nstates-1, 0.0);
+  vector<double> samples(nstates, 0.0);
+  
+  for(int i=0;i<(nstates-1);i++){
+    cuts[i] = Random::uniform(0.0, 1.0);
+  }
+  sort(cuts.begin(),cuts.end());
+  
+  samples[0] = cuts[0];
+  for(int i=1;i<(nstates-1);i++){
+    samples[i] = cuts[i] - cuts[i-1];
+  }
+  samples[nstates-1] = 1.0 - cuts[nstates-2];
+  
+  int maxi = 0;
+  double maxv = samples[0];
+  for(int i=1;i<(nstates-1);i++){
+    if(samples[i] > maxv){
+      maxi = i;
+      maxv = samples[i];
+    }
+  }
+  double tmp = samples[active_state];
+  samples[active_state] = samples[maxi];
+  samples[maxi] = tmp;
+
+  return samples;
+}
+
 
 }// namespace librandom
 }// namespace liblibra

--- a/src/math_random/random.h
+++ b/src/math_random/random.h
@@ -75,6 +75,8 @@ class Random{
   int poiss2(double lambda);
   double p_poiss(int k,double lambda); // how the distribution should look like
 
+  // Even sampling of n-dimensional Voronoi tessellation-like regions
+  vector<double> voron(int nstates, int active_state);
 }; // class Random
 
 


### PR DESCRIPTION
Added option to sample nuclear degrees of freedom with independent, user defined standard deviations for position and momenta.
Added option to sample electronic coefficients within Voronoi tessellation-like regions for use with MASH dynamics 