### PR TITLE
Organize the turning-point algorithms in MQCXF

### DIFF
--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -1357,7 +1357,7 @@ void compute_dynamics(dyn_variables& dyn_var, bp::dict dyn_params,
       }// AFSSH
       else if(prms.decoherence_algo==3){ ;; } // BCSH of Linjun Wang, nothing to do here
       else if(prms.decoherence_algo==4){ ;; } // MF-SD of Bedard-Hearn, Larsen, Schwartz, nothing to do here 
-      else if(prms.decoherence_algo==5){  shxf(dyn_var, act_states, old_states);   } // SHXF
+      else if(prms.decoherence_algo==5 or prms.decoherence_algo==6){  xf_hop_reset(dyn_var, act_states, old_states);   } // SHXF or MQCXF
 
     }
     // DISH - the old one

--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -1357,7 +1357,8 @@ void compute_dynamics(dyn_variables& dyn_var, bp::dict dyn_params,
       }// AFSSH
       else if(prms.decoherence_algo==3){ ;; } // BCSH of Linjun Wang, nothing to do here
       else if(prms.decoherence_algo==4){ ;; } // MF-SD of Bedard-Hearn, Larsen, Schwartz, nothing to do here 
-      else if(prms.decoherence_algo==5 or prms.decoherence_algo==6){  xf_hop_reset(dyn_var, act_states, old_states);   } // SHXF or MQCXF
+      //else if(prms.decoherence_algo==5 or prms.decoherence_algo==6){  xf_hop_reset(dyn_var, act_states, old_states);   } // SHXF or MQCXF
+      else if(prms.decoherence_algo==5){  xf_hop_reset(dyn_var, act_states, old_states);   } // SHXF or MQCXF
 
     }
     // DISH - the old one

--- a/src/dyn/dyn_decoherence.h
+++ b/src/dyn/dyn_decoherence.h
@@ -70,12 +70,11 @@ CMATRIX bcsh(CMATRIX& Coeff, double dt, vector<int>& act_states, MATRIX& reversa
 CMATRIX mfsd(MATRIX& p, CMATRIX& Coeff, MATRIX& invM, double dt, vector<MATRIX>& decoherence_rates, nHamiltonian& ham, Random& rnd, int isNBRA);
 CMATRIX mfsd(MATRIX& p, CMATRIX& Coeff, MATRIX& invM, double dt, vector<MATRIX>& decoherence_rates, nHamiltonian& ham, Random& rnd);
 
-// For SHXF
-void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn_control_params& prms);
-void shxf(dyn_variables& dyn_var, vector<int>& accepted_states, vector<int>& initial_states);
+// Independent-trajectory XF methods
+void xf_hop_reset(dyn_variables& dyn_var, vector<int>& accepted_states, vector<int>& initial_states);
 
-// For MQCXF
-void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn_control_params& prms);
+void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn_control_params& prms); // For SHXF
+void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn_control_params& prms); // For MQCXF
 
 // XF propagation
 void update_forces_xf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev);

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1235,7 +1235,10 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
             double alpha = compute_kinetic_energy(p_real, invM) + Epot_old - Epot;
 
             if(alpha > 0.0){alpha /= compute_kinetic_energy(p_real, invM);}
-            else{alpha = 0.0;}
+            else{
+              alpha = 0.0;
+              cout << "Energy is drifted due to a classically forbidden hop" << endl;
+            }
 
             for(int idof=0; idof<dyn_var.ndof; idof++){
               dyn_var.p->set(idof, traj, dyn_var.p->get(idof, traj) * sqrt(alpha));
@@ -1263,11 +1266,12 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
     MATRIX p_real(ndof, 1);
     p_real = dyn_var.p->col(traj); 
     double Ekin = compute_kinetic_energy(p_real, invM);
-  
+
+    double e = 1.0e-6; // masking for classical turning points
     for(int i=0; i<nadi; i++){
       if(is_mixed[i]==1){
         for(int idof=0; idof<ndof; idof++){
-          nab_phase.set(i, idof, -0.5*E.get(i,i).real()*dyn_var.p->get(idof,traj)/Ekin);
+          nab_phase.set(i, idof, -0.5*E.get(i,i).real()*dyn_var.p->get(idof,traj)/(Ekin + e));
         }//idof
       }
     }//i

--- a/src/dyn/libdyn.cpp
+++ b/src/dyn/libdyn.cpp
@@ -350,14 +350,14 @@ void export_dyn_decoherence_objects(){
   (MATRIX& p, CMATRIX& Coeff, MATRIX& invM, double dt, vector<MATRIX>& decoherence_rates, 
    nHamiltonian& ham, Random& rnd) = &mfsd;
   def("mfsd", expt_mfsd_v2);
+  
+  void (*expt_xf_hop_reset)
+  (dyn_variables& dyn_var, vector<int>& accepted_states, vector<int>& initial_states) = &xf_hop_reset;
+  def("xf_hop_reset", expt_xf_hop_reset);
 
   void (*expt_shxf_v1)
   (dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn_control_params& prms) = &shxf;
   def("shxf", expt_shxf_v1);
-  
-  void (*expt_shxf_v2)
-  (dyn_variables& dyn_var, vector<int>& accepted_states, vector<int>& initial_states) = &shxf;
-  def("shxf", expt_shxf_v2);
   
   void (*expt_mqcxf_v1)
   (dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn_control_params& prms) = &mqcxf;


### PR DESCRIPTION
Add the momentum rescaling when the dynamics is initialized in MQCXF.

Diverging phase vectors are prevented by adding a small factor to the denominator (kinetic energy).

Needs to deal with the consistency between electronic propagations.