### PR TITLE
Update the XF algorithms

### DIFF
--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -598,6 +598,21 @@ void update_wp_width(dyn_variables& dyn_var, dyn_control_params& prms){
       }
     }
   }
+  else if (prms.use_td_width == 2){
+    double elapsed_time, s2;
+
+    elapsed_time = prms.dt*dyn_var.timestep;
+    
+    for(int itraj=0; itraj<ntraj; itraj++){
+      for(int idof=0; idof<ndof; idof++){
+        s2 = pow(prms.wp_width->get(idof,0), 2.0);
+        dyn_var.wp_width->set(idof, itraj, 4*M_PI/(s2*dyn_var.p->get(idof, itraj)) );
+      }
+    }
+  }
+  else if (prms.use_td_width == 3){
+    ;;
+  }
 }
 
 /*

--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -1217,13 +1217,13 @@ void compute_dynamics(dyn_variables& dyn_var, bp::dict dyn_params,
   // basis re-projection matrices 
   for(i=0; i<num_el; i++){
     if(prms.decoherence_algo == 5 or prms.decoherence_algo == 6){
-      propagate_half_xf(dyn_var, ham, prms);
+      propagate_half_xf(dyn_var, ham, prms, 0);
     }
 
     propagate_electronic(dyn_var, ham, ham_aux, prms);
 
     if(prms.decoherence_algo == 5 or prms.decoherence_algo == 6){
-      propagate_half_xf(dyn_var, ham, prms);
+      propagate_half_xf(dyn_var, ham, prms, 1);
     }
   }
 

--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -570,6 +570,36 @@ void remove_thermal_correction(dyn_variables& dyn_var, nHamiltonian& ham, dyn_co
 
 }
 
+void update_wp_width(dyn_variables& dyn_var, dyn_control_params& prms){
+/**
+  Updates the wave packet width in XF based on the Gaussian approximation
+*/
+  
+  //======= Parameters of the dyn variables ==========
+  int ndof = dyn_var.ndof;
+  int ntraj = dyn_var.ntraj;
+
+  if (prms.use_td_width == 0){
+    for(int itraj=0; itraj<ntraj; itraj++){
+      for(int idof=0; idof<ndof; idof++){
+        dyn_var.wp_width->set(idof, itraj, prms.wp_width->get(idof, 0));
+      }
+    }
+  }
+  else if (prms.use_td_width == 1){
+    double elapsed_time, s2;
+    
+    elapsed_time = prms.dt*dyn_var.timestep;
+
+    for(int itraj=0; itraj<ntraj; itraj++){
+      for(int idof=0; idof<ndof; idof++){
+        s2 = pow(prms.wp_width->get(idof, 0), 2.0) + pow(prms.wp_v->get(idof, 0)*elapsed_time, 2.0);
+        dyn_var.wp_width->set(idof, itraj, sqrt(s2));
+      }
+    }
+  }
+}
+
 /*
 void update_proj_adi(dyn_variables& dyn_var, nHamiltonian* Ham, nHamiltonian* Ham_prev, dyn_control_params& prms){
 
@@ -1212,18 +1242,23 @@ void compute_dynamics(dyn_variables& dyn_var, bp::dict dyn_params,
   // Recompute NAC, Hvib, etc. in response to change of p
   update_Hamiltonian_variables(prms, dyn_var, ham, ham_aux, py_funct, params, 1);
 
+  // Update wave packet width in XF algorithm
+  if(prms.decoherence_algo == 5 or prms.decoherence_algo == 6){
+    dyn_var.get_current_timestep(params);
+    update_wp_width(dyn_var, prms);  
+  }
 
   // Propagate electronic coefficients in the [t, t + dt] interval, this also updates the 
   // basis re-projection matrices 
   for(i=0; i<num_el; i++){
     if(prms.decoherence_algo == 5 or prms.decoherence_algo == 6){
-      propagate_half_xf(dyn_var, ham, prms, params, 0);
+      propagate_half_xf(dyn_var, ham, prms, 0);
     }
 
     propagate_electronic(dyn_var, ham, ham_aux, prms);
 
     if(prms.decoherence_algo == 5 or prms.decoherence_algo == 6){
-      propagate_half_xf(dyn_var, ham, prms, params, 1);
+      propagate_half_xf(dyn_var, ham, prms, 1);
     }
   }
 

--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -1217,13 +1217,13 @@ void compute_dynamics(dyn_variables& dyn_var, bp::dict dyn_params,
   // basis re-projection matrices 
   for(i=0; i<num_el; i++){
     if(prms.decoherence_algo == 5 or prms.decoherence_algo == 6){
-      propagate_half_xf(dyn_var, ham, prms, 0);
+      propagate_half_xf(dyn_var, ham, prms, params, 0);
     }
 
     propagate_electronic(dyn_var, ham, ham_aux, prms);
 
     if(prms.decoherence_algo == 5 or prms.decoherence_algo == 6){
-      propagate_half_xf(dyn_var, ham, prms, 1);
+      propagate_half_xf(dyn_var, ham, prms, params, 1);
     }
   }
 

--- a/src/dyn/dyn_control_params.cpp
+++ b/src/dyn/dyn_control_params.cpp
@@ -79,8 +79,8 @@ dyn_control_params::dyn_control_params(){
   collapse_option = 0;
   decoherence_rates = NULL;
   ave_gaps = NULL;
-  wp_width = 0.1;
-  wp_v = 0.0;
+  wp_width = NULL;
+  wp_v = NULL;
   coherence_threshold = 0.01;
   e_mask = 0.0001;
   use_xf_force = 0;
@@ -163,8 +163,11 @@ dyn_control_params::dyn_control_params(const dyn_control_params& x){
   dephasing_informed = x.dephasing_informed;
   instantaneous_decoherence_variant = x.instantaneous_decoherence_variant; 
   collapse_option = x.collapse_option;
-  wp_width = x.wp_width;
-  wp_v = x.wp_v;
+
+  wp_width = new MATRIX( x.wp_width->n_rows, x.wp_width->n_cols );
+  *wp_width = *x.wp_width;
+  wp_v = new MATRIX( x.wp_v->n_rows, x.wp_v->n_cols );
+  *wp_v = *x.wp_v;
   coherence_threshold = x.coherence_threshold;
   e_mask = x.e_mask;
   use_xf_force = x.use_xf_force;
@@ -216,6 +219,8 @@ dyn_control_params::~dyn_control_params() {
 
   //cout<<"dyn_control_params destructor\n";
 
+  delete wp_width;
+  delete wp_v;
   delete decoherence_rates;  
   delete ave_gaps;
   delete schwartz_decoherence_inv_alpha;
@@ -354,8 +359,20 @@ void dyn_control_params::set_parameters(bp::dict params){
         for(int b=0;b<x.n_cols;b++){ ave_gaps->set(a, b, x.get(a,b));   }
       } 
     }
-    else if(key=="wp_width"){ wp_width = bp::extract<double>(params.values()[i]); }
-    else if(key=="wp_v"){ wp_v = bp::extract<double>(params.values()[i]); }
+    else if(key=="wp_width"){ 
+      MATRIX x( bp::extract<MATRIX>(params.values()[i]) );
+      wp_width = new MATRIX(x.n_rows, x.n_cols);      
+      for(int a=0;a<x.n_rows;a++){
+        for(int b=0;b<x.n_cols;b++){ wp_width->set(a, b, x.get(a,b));   }
+      } 
+    }
+    else if(key=="wp_v"){ 
+      MATRIX x( bp::extract<MATRIX>(params.values()[i]) );
+      wp_v = new MATRIX(x.n_rows, x.n_cols);      
+      for(int a=0;a<x.n_rows;a++){
+        for(int b=0;b<x.n_cols;b++){ wp_v->set(a, b, x.get(a,b));   }
+      } 
+    }
     else if(key=="coherence_threshold"){ coherence_threshold = bp::extract<double>(params.values()[i]); }
     else if(key=="e_mask"){ e_mask = bp::extract<double>(params.values()[i]); }
     else if(key=="use_xf_force"){ use_xf_force = bp::extract<int>(params.values()[i]); }

--- a/src/dyn/dyn_control_params.cpp
+++ b/src/dyn/dyn_control_params.cpp
@@ -83,6 +83,7 @@ dyn_control_params::dyn_control_params(){
   coherence_threshold = 0.01;
   use_xf_force = 0;
   project_out_aux = 0;
+  tp_algo = 1;
 
   ///================= Entanglement of trajectories ================================
   entanglement_opt = 0;
@@ -163,6 +164,7 @@ dyn_control_params::dyn_control_params(const dyn_control_params& x){
   coherence_threshold = x.coherence_threshold;
   use_xf_force = x.use_xf_force;
   project_out_aux = x.project_out_aux;
+  tp_algo = x.tp_algo;
 
   ///================= Entanglement of trajectories ================================
   entanglement_opt = x.entanglement_opt;
@@ -350,6 +352,7 @@ void dyn_control_params::set_parameters(bp::dict params){
     else if(key=="coherence_threshold"){ coherence_threshold = bp::extract<double>(params.values()[i]); }
     else if(key=="use_xf_force"){ use_xf_force = bp::extract<int>(params.values()[i]); }
     else if(key=="project_out_aux"){ project_out_aux = bp::extract<int>(params.values()[i]); }
+    else if(key=="tp_algo"){ tp_algo = bp::extract<int>(params.values()[i]); }
 
     ///================= Entanglement of trajectories ================================
     else if(key=="entanglement_opt"){ entanglement_opt = bp::extract<int>(params.values()[i]); }

--- a/src/dyn/dyn_control_params.cpp
+++ b/src/dyn/dyn_control_params.cpp
@@ -81,6 +81,7 @@ dyn_control_params::dyn_control_params(){
   ave_gaps = NULL;
   wp_width = 0.1;
   coherence_threshold = 0.01;
+  e_mask = 0.0001;
   use_xf_force = 0;
   project_out_aux = 0;
   tp_algo = 1;
@@ -162,6 +163,7 @@ dyn_control_params::dyn_control_params(const dyn_control_params& x){
   collapse_option = x.collapse_option;
   wp_width = x.wp_width;
   coherence_threshold = x.coherence_threshold;
+  e_mask = x.e_mask;
   use_xf_force = x.use_xf_force;
   project_out_aux = x.project_out_aux;
   tp_algo = x.tp_algo;
@@ -350,6 +352,7 @@ void dyn_control_params::set_parameters(bp::dict params){
     }
     else if(key=="wp_width"){ wp_width = bp::extract<double>(params.values()[i]); }
     else if(key=="coherence_threshold"){ coherence_threshold = bp::extract<double>(params.values()[i]); }
+    else if(key=="e_mask"){ e_mask = bp::extract<double>(params.values()[i]); }
     else if(key=="use_xf_force"){ use_xf_force = bp::extract<int>(params.values()[i]); }
     else if(key=="project_out_aux"){ project_out_aux = bp::extract<int>(params.values()[i]); }
     else if(key=="tp_algo"){ tp_algo = bp::extract<int>(params.values()[i]); }

--- a/src/dyn/dyn_control_params.cpp
+++ b/src/dyn/dyn_control_params.cpp
@@ -80,11 +80,13 @@ dyn_control_params::dyn_control_params(){
   decoherence_rates = NULL;
   ave_gaps = NULL;
   wp_width = 0.1;
+  wp_v = 0.0;
   coherence_threshold = 0.01;
   e_mask = 0.0001;
   use_xf_force = 0;
   project_out_aux = 0;
   tp_algo = 1;
+  use_td_width = 0;
 
   ///================= Entanglement of trajectories ================================
   entanglement_opt = 0;
@@ -162,11 +164,13 @@ dyn_control_params::dyn_control_params(const dyn_control_params& x){
   instantaneous_decoherence_variant = x.instantaneous_decoherence_variant; 
   collapse_option = x.collapse_option;
   wp_width = x.wp_width;
+  wp_v = x.wp_v;
   coherence_threshold = x.coherence_threshold;
   e_mask = x.e_mask;
   use_xf_force = x.use_xf_force;
   project_out_aux = x.project_out_aux;
   tp_algo = x.tp_algo;
+  use_td_width = x.use_td_width;
 
   ///================= Entanglement of trajectories ================================
   entanglement_opt = x.entanglement_opt;
@@ -351,11 +355,13 @@ void dyn_control_params::set_parameters(bp::dict params){
       } 
     }
     else if(key=="wp_width"){ wp_width = bp::extract<double>(params.values()[i]); }
+    else if(key=="wp_v"){ wp_v = bp::extract<double>(params.values()[i]); }
     else if(key=="coherence_threshold"){ coherence_threshold = bp::extract<double>(params.values()[i]); }
     else if(key=="e_mask"){ e_mask = bp::extract<double>(params.values()[i]); }
     else if(key=="use_xf_force"){ use_xf_force = bp::extract<int>(params.values()[i]); }
     else if(key=="project_out_aux"){ project_out_aux = bp::extract<int>(params.values()[i]); }
     else if(key=="tp_algo"){ tp_algo = bp::extract<int>(params.values()[i]); }
+    else if(key=="use_td_width"){ use_td_width = bp::extract<int>(params.values()[i]); }
 
     ///================= Entanglement of trajectories ================================
     else if(key=="entanglement_opt"){ entanglement_opt = bp::extract<int>(params.values()[i]); }

--- a/src/dyn/dyn_control_params.h
+++ b/src/dyn/dyn_control_params.h
@@ -533,8 +533,9 @@ class dyn_control_params{
 
   Options:
       - 0: no treatment of a turning point
-      - 1: fix auxiliary trajectories of adiabatic states other than the active state [default]
-      - 2: collapse to the active state
+      - 1: collapse to the active state [default]
+      - 2: fix auxiliary positions of adiabatic states except for the active state
+      - 3: keep auxiliary momenta of adiabatic states except for the active state
   */
   int tp_algo;
 

--- a/src/dyn/dyn_control_params.h
+++ b/src/dyn/dyn_control_params.h
@@ -503,18 +503,18 @@ class dyn_control_params{
 
 
   /**
-  The width of Gaussian for the decoherence from SHXF & MQCXF
-  [ default : 0.1 ]
+  MATRIX(ndof, 1) of (initial) wave packet widths for the decoherence from SHXF & MQCXF
+  [ default : NULL ]
   */
-  double wp_width;
+  MATRIX* wp_width;
 
 
   /**
-  The velocity of Gaussian for the decoherence from SHXF & MQCXF
+  MATRIX(ndof, 1) of wave packet velocities for the decoherence from SHXF & MQCXF
   This value is applied when use_td_width = 1
-  [ default : 0.0 ]
+  [ default : NULL ]
   */
-  double wp_v;
+  MATRIX* wp_v;
 
 
   /**

--- a/src/dyn/dyn_control_params.h
+++ b/src/dyn/dyn_control_params.h
@@ -514,7 +514,15 @@ class dyn_control_params{
   [ default : 0.01 ]
   */
   double coherence_threshold;
-  
+
+
+  /**
+  The masking parameter for computing nabla phase vectors in the MQCXF
+  [ default : 0.0001 ]
+  */
+  double e_mask;
+
+
   /**
   Whether to use the decoherence force in MQCXF
   The corresponding electronic propagation is adjusted for the energy conservation
@@ -522,11 +530,13 @@ class dyn_control_params{
   */
   int use_xf_force;
 
+
   /**
   Whether to project out the density on an auxiliary trajectory when its motion is classically forbidden
   [ default : 0 ]
   */
   int project_out_aux;
+
 
   /**
   Turning-point algorithm for auxiliary trajectories
@@ -538,6 +548,7 @@ class dyn_control_params{
       - 3: keep auxiliary momenta of adiabatic states except for the active state
   */
   int tp_algo;
+
 
   /**
   A flag for NBRA calculations. Since in NBRA, the Hamiltonian is the same for all the trajectories

--- a/src/dyn/dyn_control_params.h
+++ b/src/dyn/dyn_control_params.h
@@ -529,6 +529,16 @@ class dyn_control_params{
   int project_out_aux;
 
   /**
+  Turning-point algorithm for auxiliary trajectories
+
+  Options:
+      - 0: no treatment of a turning point
+      - 1: fix auxiliary trajectories of adiabatic states other than the active state [default]
+      - 2: collapse to the active state
+  */
+  int tp_algo;
+
+  /**
   A flag for NBRA calculations. Since in NBRA, the Hamiltonian is the same for all the trajectories
   we can only compute the Hamiltonian related properties once for one trajectory and increase the speed of calculations.
   If we set the value to 1 it will consider the NBRA type calculations and other integers the Hamiltonian related properties

--- a/src/dyn/dyn_control_params.h
+++ b/src/dyn/dyn_control_params.h
@@ -503,10 +503,18 @@ class dyn_control_params{
 
 
   /**
-  The width of frozen Gaussian for the decoherence from SHXF & MQCXF
+  The width of Gaussian for the decoherence from SHXF & MQCXF
   [ default : 0.1 ]
   */
   double wp_width;
+
+
+  /**
+  The velocity of Gaussian for the decoherence from SHXF & MQCXF
+  This value is applied when use_td_width = 1
+  [ default : 0.0 ]
+  */
+  double wp_v;
 
 
   /**
@@ -548,6 +556,16 @@ class dyn_control_params{
       - 3: keep auxiliary momenta of adiabatic states except for the active state
   */
   int tp_algo;
+  
+
+  /**
+  Whether to use the td Gaussian width for the nuclear wave packet approximation
+  This option can be considered when it comes to unbounded systems.
+  This approximation is based on a nuclear wave packet on a free surface:
+    \sigma_x(t)=\sqrt[\sigma_x(0)^2 + (wp_v * t)^2]
+  [ default : 0 ]
+  */
+  int use_td_width;
 
 
   /**

--- a/src/dyn/dyn_decoherence.h
+++ b/src/dyn/dyn_decoherence.h
@@ -81,7 +81,7 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
 
 // XF propagation
 void update_forces_xf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev);
-void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& ham, dyn_control_params& prms, int rotation);
+void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& ham, dyn_control_params& prms, bp::dict params, int rotation);
 void XF_correction(CMATRIX& Ham, dyn_variables& dyn_var, CMATRIX& C, double wp_width, CMATRIX& T, int traj);
 
 ///================  In dyn_decoherence_time.cpp  ===================================

--- a/src/dyn/dyn_decoherence.h
+++ b/src/dyn/dyn_decoherence.h
@@ -81,7 +81,7 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
 
 // XF propagation
 void update_forces_xf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev);
-void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& ham, dyn_control_params& prms);
+void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& ham, dyn_control_params& prms, int rotation);
 void XF_correction(CMATRIX& Ham, dyn_variables& dyn_var, CMATRIX& C, double wp_width, CMATRIX& T, int traj);
 
 ///================  In dyn_decoherence_time.cpp  ===================================

--- a/src/dyn/dyn_decoherence.h
+++ b/src/dyn/dyn_decoherence.h
@@ -81,7 +81,7 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
 
 // XF propagation
 void update_forces_xf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev);
-void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& ham, dyn_control_params& prms, bp::dict params, int rotation);
+void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& ham, dyn_control_params& prms, int rotation);
 void XF_correction(CMATRIX& Ham, dyn_variables& dyn_var, CMATRIX& C, double wp_width, CMATRIX& T, int traj);
 
 ///================  In dyn_decoherence_time.cpp  ===================================

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1166,7 +1166,7 @@ void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn
     MATRIX& p_aux_old = *dyn_var.p_aux_old[traj];
     
     int a = dyn_var.act_states[traj];
-
+    
     MATRIX p_real(ndof, 1); 
     MATRIX p_aux_temp(ndof, 1);
     
@@ -1218,11 +1218,21 @@ void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn
 
         // Check the turning point
         if (is_first[i] == 0 and prms.tp_algo != 0){
-          double temp = 0.0;
-          for(int idof=0; idof<ndof; idof++){temp += p_aux_old.get(i, idof)*p_aux.get(i,idof);}
-          if(temp<0.0){
+          MATRIX Fa(ndof, 1);
+          for(int idof=0; idof<ndof; idof++){
+            Fa.set(idof, 0, dyn_var.f->get(idof,0) );
+          }
+          double dp_old = 0.0;
+          double dp_new = 0.0;
+
+          for(int idof=0; idof<ndof; idof++){
+            dp_old += Fa.get(idof, 0) * p_aux_old.get(i, idof);
+            dp_new += Fa.get(idof, 0) * p_aux.get(i, idof);
+          }
+
+          if(dp_old*dp_new < 0.0){
             is_tp = 1;
-            //break;
+            break;
           }
         }
 
@@ -1404,18 +1414,27 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
         
         // Check the turning point
         if (is_first[i] == 0 and prms.tp_algo != 0){
-          double temp = 0.0;
-          for(int idof=0; idof<ndof; idof++){temp += p_aux_old.get(i, idof)*p_aux.get(i,idof);}
-          if(temp<0.0){
-            is_tp = 1;
-            //break;
+          MATRIX Fa(ndof, 1);
+          for(int idof=0; idof<ndof; idof++){
+            Fa.set(idof, 0, dyn_var.f->get(idof,0) );
+          }
+          double dp_old = 0.0;
+          double dp_new = 0.0;
 
+          for(int idof=0; idof<ndof; idof++){
+            dp_old += Fa.get(idof, 0) * p_aux_old.get(i, idof);
+            dp_new += Fa.get(idof, 0) * p_aux.get(i, idof);
+          }
+
+          if(dp_old*dp_new < 0.0){
+            is_tp = 1;
+            break;
           }
         }
 
       }
     }//i
-    
+
     if(is_tp == 1){
       if(prms.tp_algo == 1){
         double Epot_old = Epot;

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1484,11 +1484,10 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
     p_real = dyn_var.p->col(traj); 
     double Ekin = compute_kinetic_energy(p_real, invM);
 
-    double e = 1.0e-4; // masking for classical turning points
     for(int i=0; i<nadi; i++){
       if(is_mixed[i]==1){
         for(int idof=0; idof<ndof; idof++){
-          nab_phase.set(i, idof, -0.5*E.get(i,i).real()*dyn_var.p->get(idof,traj)/(Ekin + e));
+          nab_phase.set(i, idof, -0.5*E.get(i,i).real()*dyn_var.p->get(idof,traj)/(Ekin + prms.e_mask));
         }//idof
       }
     }//i

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1403,6 +1403,8 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
     vector<int>& is_keep = dyn_var.is_keep[traj];
     MATRIX& p_aux = *dyn_var.p_aux[traj];
     MATRIX& p_aux_old = *dyn_var.p_aux_old[traj];
+    
+    int a = dyn_var.act_states[traj];
 
     MATRIX p_real(ndof, 1); 
     MATRIX p_aux_temp(ndof, 1);
@@ -1440,7 +1442,7 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
         }
 
         if (alpha < 0.0){ alpha = 0.0;
-          if (prms.project_out_aux == 1){
+          if (prms.project_out_aux == 1 and i!=a){
             project_out(*dyn_var.ampl_adi, traj, i);
             xf_init_AT(dyn_var, traj, -1);
             cout << "Project out a classically forbidden state " << i << " on traj " << traj <<endl;

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1226,6 +1226,11 @@ void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn
 
     if(is_tp == 1){
       if(prms.tp_algo == 1){
+        collapse(*dyn_var.ampl_adi, traj, a, 0);
+        xf_init_AT(dyn_var, traj, -1);
+        cout << "Collapse to the active state " << a << " at a classical turning point on traj " << traj <<endl;
+      }
+      else if(prms.tp_algo == 2){
         for(int i=0; i<nadi; i++){
           if(i == a){continue;}
           
@@ -1236,11 +1241,6 @@ void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn
           is_fixed[i] = 1;
         }//i
         cout << "Fix auxiliary trajectory except for the active state " << a << " at a classical turning point on traj " << traj <<endl;
-      }
-      else if(prms.tp_algo == 2){
-        collapse(*dyn_var.ampl_adi, traj, a, 0);
-        xf_init_AT(dyn_var, traj, -1);
-        cout << "Collapse to the active state " << a << " at a classical turning point on traj " << traj <<endl;
       }
       else if(prms.tp_algo == 3){
         for(int i=0; i<nadi; i++){
@@ -1413,19 +1413,6 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
     
     if(is_tp == 1){
       if(prms.tp_algo == 1){
-        int a = dyn_var.act_states[traj];
-        for(int i=0; i<nadi; i++){
-          if(i == a){continue;}
-          
-          for(int idof=0; idof<ndof; idof++){
-            p_aux.set(i, idof, 0.0);
-            p_aux_old.set(i, idof, 0.0);
-          }
-          is_fixed[i] = 1;
-        }//i
-        cout << "Fix auxiliary trajectory except for the active state " << a << " at a classical turning point on traj " << traj <<endl;
-      }
-      else if(prms.tp_algo == 2){
         double Epot_old = Epot;
 
         int a = dyn_var.act_states[traj];
@@ -1451,6 +1438,19 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
 
         xf_init_AT(dyn_var, traj, -1);
         cout << "Collapse to the active state " << a << " at a classical turning point on traj " << traj <<endl;
+      }
+      else if(prms.tp_algo == 2){
+        int a = dyn_var.act_states[traj];
+        for(int i=0; i<nadi; i++){
+          if(i == a){continue;}
+          
+          for(int idof=0; idof<ndof; idof++){
+            p_aux.set(i, idof, 0.0);
+            p_aux_old.set(i, idof, 0.0);
+          }
+          is_fixed[i] = 1;
+        }//i
+        cout << "Fix auxiliary trajectory except for the active state " << a << " at a classical turning point on traj " << traj <<endl;
       }
       else if(prms.tp_algo == 3){
         int a = dyn_var.act_states[traj];

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1497,25 +1497,7 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
   } // traj
 }
 
-double compute_wp_width(dyn_variables& dyn_var, dyn_control_params& prms, bp::dict params, double dt){
-  double elapsed_time, s2;
-  int it;
-    
-  std::string key;
-  for(int i=0;i<len(params.values());i++){
-    key = bp::extract<std::string>(params.keys()[i]);
-    if(key=="timestep") { it = bp::extract<int>(params.values()[i]); }
-    else {continue;}
-  }
-
-  elapsed_time = dt*it;
-  s2 = pow(prms.wp_width, 2.0) + pow(prms.wp_v*elapsed_time, 2.0);
-
-  return sqrt(s2); 
-  
-}
-
-void XF_correction(CMATRIX& Ham, dyn_variables& dyn_var, CMATRIX& C, double wp_width, CMATRIX& T, int traj){
+void XF_correction(CMATRIX& Ham, dyn_variables& dyn_var, CMATRIX& C, CMATRIX& T, int traj){
 
   int ndof = dyn_var.ndof;
   int nst = dyn_var.nadi;
@@ -1534,7 +1516,7 @@ void XF_correction(CMATRIX& Ham, dyn_variables& dyn_var, CMATRIX& C, double wp_w
   for(int i=0; i<nst; i++){
     if(is_mixed[i]==1){
       for(int idof=0; idof<ndof; idof++){
-        dyn_var.p_quant->add(idof, traj, 0.5 / pow(wp_width, 2.0) * RHO.get(i,i).real()
+        dyn_var.p_quant->add(idof, traj, 0.5 / pow(dyn_var.wp_width->get(idof, traj), 2.0) * RHO.get(i,i).real()
           *(dyn_var.q_aux[traj]->get(a, idof) - dyn_var.q_aux[traj]->get(i, idof)));
          // *(dyn_var.q->get(idof, traj) - dyn_var.q_aux[traj]->get(i, idof)));
       }
@@ -1633,7 +1615,7 @@ void update_forces_xf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& h
   *dyn_var.f += *dyn_var.f_xf;
 }
 
-void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& Ham, dyn_control_params& prms, bp::dict params, int rotation){
+void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& Ham, dyn_control_params& prms, int rotation){
   int itraj, i, j;
 
   int num_el = prms.num_electronic_substeps;
@@ -1667,24 +1649,14 @@ void propagate_half_xf(dyn_variables& dyn_var, nHamiltonian& Ham, dyn_control_pa
     if(prms.assume_always_consistent){ T_new.identity(); }
 
     // Generate the half-time exponential operator 
-    CMATRIX Hxf_old(nadi, nadi);
     CMATRIX Hxf(nadi, nadi);
     CMATRIX D(nadi, nadi); /// this is \exp[-idt/4\hbar * ( T_new.H()*Hxf(t+dt)*T_new + Hxf(t) )]
 
-    double wp_width;
-    if (prms.use_td_width == 1){
-      wp_width = compute_wp_width(dyn_var, prms, params, dt);
-    }
-    else{
-      wp_width = prms.wp_width;
-    }
-
-    XF_correction(Hxf_old, dyn_var, C, wp_width, T, itraj);
-    //XF_correction(Hxf, dyn_var, C, prms.wp_width, T, itraj);
+    XF_correction(Hxf, dyn_var, C, T, itraj);
+    //XF_correction(Hxf, dyn_var, C, T, itraj);
 
     //Hxf = T_new.H() * Hxf * T_new;      
     //Hxf += Hxf_old;
-    Hxf = Hxf_old;
 
     D = libspecialfunctions::exp_(Hxf, complex<double>(0.0, -0.5*dt) );
     if(rotation == 1){

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1368,9 +1368,9 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
           alpha = compute_kinetic_energy(p_real, invM) + Epot - ham_adi.get(i,i).real();
         }
         else{
-          p_aux_temp = p_aux_old.row(i).T(); 
-          alpha = compute_kinetic_energy(p_aux_temp, invM) + ham_adi_prev.get(i,i).real() - ham_adi.get(i,i).real();
-          //alpha = compute_kinetic_energy(p_real, invM) + Epot - ham_adi.get(i,i).real();
+          //p_aux_temp = p_aux_old.row(i).T(); 
+          //alpha = compute_kinetic_energy(p_aux_temp, invM) + ham_adi_prev.get(i,i).real() - ham_adi.get(i,i).real();
+          alpha = compute_kinetic_energy(p_real, invM) + Epot - ham_adi.get(i,i).real();
         }
 
         if (alpha < 0.0){ alpha = 0.0;

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1075,7 +1075,10 @@ void xf_create_AT(dyn_variables& dyn_var, double threshold){
       int nr_mixed = 0; 
       for(int i=0; i<nadi; i++){
         double a_ii = dm.get(i,i).real(); 
-        if(a_ii<=lower_lim || a_ii>upper_lim){is_mixed[i]=0;}
+        if(a_ii<=lower_lim || a_ii>upper_lim){
+          is_mixed[i]=0;
+          xf_init_AT(dyn_var, traj, i);
+        }
         else{
           is_mixed[i]==1 ? is_first[i]=0:is_first[i]=1;
           is_mixed[i]=1;

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1529,7 +1529,9 @@ void XF_correction(CMATRIX& Ham, dyn_variables& dyn_var, CMATRIX& C, double wp_w
     // Set a diagonal matrix of nabla_phase for each dof
     CMATRIX F(nst, nst);
     for(int i=0; i<nst; i++){
-      F.set(i,i, complex<double>(0.0, dyn_var.nab_phase[traj]->get(i, idof)) );
+      if(is_mixed[i]==1){
+        F.set(i,i, complex<double>(0.0, dyn_var.nab_phase[traj]->get(i, idof)) );
+      }
     }
     F = T * F * T.H();
 
@@ -1573,10 +1575,13 @@ void update_forces_xf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& h
     double Ekin = compute_kinetic_energy(p_real, invM);
 
     // Compute F for each dof
+    vector<int>& is_mixed = dyn_var.is_mixed[traj];
     for(int idof=0; idof<ndof; idof++){
       F[idof].set(-1,-1, complex<double> (0.0, 0.0));
       for(int i=0; i<nst; i++){
-        F[idof].set(i,i,complex<double> (dyn_var.nab_phase[traj]->get(i, idof), 0.0) );
+        if(is_mixed[i]==1){
+          F[idof].set(i,i,complex<double> (dyn_var.nab_phase[traj]->get(i, idof), 0.0) );
+        }
       }
     }
 

--- a/src/dyn/dyn_decoherence_methods.cpp
+++ b/src/dyn/dyn_decoherence_methods.cpp
@@ -1108,6 +1108,56 @@ for(traj = 0; traj < ntraj; traj++){
   }// traj
 }
 
+void td_width_aux(dyn_variables& dyn_var){
+  int ntraj = dyn_var.ntraj;
+  int nadi = dyn_var.nadi;
+  int ndof = dyn_var.ndof; 
+
+  double width_temp;
+
+  dyn_var.wp_width->set(-1, -1, 0.0);
+  for(int traj=0; traj<ntraj; traj++){
+    vector<int>& is_mixed = dyn_var.is_mixed[traj];
+    vector<int>& is_first = dyn_var.is_first[traj];
+
+    // wp_width is computed by pairwise widths based on auxiliary trajectories
+    MATRIX sum_inv_w2(ndof, 1);
+    MATRIX w2_temp(ndof, 1);
+    
+    int check_mixing = 0;
+    for(int i=0; i<nadi; i++){
+      for(int j=0; j<nadi; j++){
+        if(i>=j){continue;}
+
+        if(is_mixed[i] == 0 or is_mixed[j] == 0){continue; }
+        check_mixing = 1;
+
+        if(is_first[i] == 1 or is_first[j] == 1){
+          w2_temp.set(-1, 1.0e+10); // At initial, an auxiliary pair does not contribute to wp_width
+        }
+        else{
+          for(int idof=0; idof<ndof; idof++){
+            w2_temp.set(idof, 0, fabs(dyn_var.q_aux[traj]->get(i, idof) - dyn_var.q_aux[traj]->get(j, idof))/
+              fabs(dyn_var.p_aux[traj]->get(i, idof) - dyn_var.p_aux[traj]->get(j, idof)) );
+          }
+        }
+
+        for(int idof=0; idof<ndof; idof++){
+          sum_inv_w2.add(idof, 0, 1.0/w2_temp.get(idof));
+        }
+
+      } //j
+    } //i
+    
+    if(check_mixing == 1){
+      for(int idof=0; idof<ndof; idof++){
+        dyn_var.wp_width->set(idof, traj, sqrt((nadi - 1)* 1.0/sum_inv_w2.get(idof, 0)) );
+      }
+    }
+
+  } // traj
+}
+
 void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn_control_params& prms){
     /**
     \brief The generic framework of the SHXF (Surface Hopping based on eXact Factorization) method of
@@ -1272,6 +1322,9 @@ void shxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dyn
       is_tp = 0;
     }
   }//traj
+
+  // Compute the td width based on auxiliary trajectories
+  if(prms.use_td_width == 3){ td_width_aux(dyn_var);}
 
   // Propagate the spatial derivative of phases
   for(int traj=0; traj<ntraj; traj++){
@@ -1492,6 +1545,9 @@ void mqcxf(dyn_variables& dyn_var, nHamiltonian& ham, nHamiltonian& ham_prev, dy
     }
 
   }//traj
+
+  // Compute the td width based on auxiliary trajectories
+  if(prms.use_td_width == 3){ td_width_aux(dyn_var);}
 
   // Propagate the spatial derivative of phases; the E-based approximation is used
   for(int traj=0; traj<ntraj; traj++){

--- a/src/dyn/dyn_variables.cpp
+++ b/src/dyn/dyn_variables.cpp
@@ -181,9 +181,13 @@ void dyn_variables::allocate_shxf(){
     for(int itraj=0; itraj<ntraj; itraj++){
       is_mixed.push_back(vector<int>());
       is_first.push_back(vector<int>());
+      is_fixed.push_back(vector<int>());
+      is_keep.push_back(vector<int>());
       for(int i=0; i<nadi; i++){
         is_mixed[itraj].push_back(0);
         is_first[itraj].push_back(0);
+        is_fixed[itraj].push_back(0);
+        is_keep[itraj].push_back(0);
       } // i
     } // itraj
 
@@ -212,9 +216,13 @@ void dyn_variables::allocate_mqcxf(){
     for(int itraj=0; itraj<ntraj; itraj++){
       is_mixed.push_back(vector<int>());
       is_first.push_back(vector<int>());
+      is_fixed.push_back(vector<int>());
+      is_keep.push_back(vector<int>());
       for(int i=0; i<nadi; i++){
         is_mixed[itraj].push_back(0);
         is_first[itraj].push_back(0);
+        is_fixed[itraj].push_back(0);
+        is_keep[itraj].push_back(0);
       } // i
     } // itraj
 

--- a/src/dyn/dyn_variables.cpp
+++ b/src/dyn/dyn_variables.cpp
@@ -203,6 +203,7 @@ void dyn_variables::allocate_shxf(){
       nab_phase[itraj] = new MATRIX(nadi, ndof);
     }
 
+    wp_width = new MATRIX(ndof, ntraj);
     p_quant = new MATRIX(ndof, ntraj);
     VP = new MATRIX(ndof, ntraj);
   
@@ -238,6 +239,7 @@ void dyn_variables::allocate_mqcxf(){
       nab_phase[itraj] = new MATRIX(nadi, ndof);
     }
 
+    wp_width = new MATRIX(ndof, ntraj);
     p_quant = new MATRIX(ndof, ntraj);
     VP = new MATRIX(ndof, ntraj);
     f_xf = new MATRIX(ndof, ntraj);
@@ -357,6 +359,7 @@ dyn_variables::dyn_variables(const dyn_variables& x){
         *p_aux_old[itraj] = *x.p_aux_old[itraj];
         *nab_phase[itraj] = *x.nab_phase[itraj];
     }
+    *wp_width = *x.wp_width;
     *p_quant = *x.p_quant;
     *VP = *x.VP;
 
@@ -373,6 +376,7 @@ dyn_variables::dyn_variables(const dyn_variables& x){
         *p_aux_old[itraj] = *x.p_aux_old[itraj];
         *nab_phase[itraj] = *x.nab_phase[itraj];
     }
+    *wp_width = *x.wp_width;
     *p_quant = *x.p_quant;
     *VP = *x.VP;
     *f_xf = *x.f_xf;
@@ -484,6 +488,7 @@ dyn_variables::~dyn_variables(){
     p_aux_old.clear();
     nab_phase.clear();
 
+    delete wp_width;
     delete p_quant;
     delete VP;
 
@@ -514,6 +519,7 @@ dyn_variables::~dyn_variables(){
     p_aux_old.clear();
     nab_phase.clear();
 
+    delete wp_width;
     delete p_quant;
     delete VP;
     delete f_xf;

--- a/src/dyn/dyn_variables.h
+++ b/src/dyn/dyn_variables.h
@@ -388,6 +388,14 @@ class dyn_variables{
      vector<ntraj, MATRIX(nadi, ndof)> 
   */
   vector<MATRIX*> nab_phase;
+  
+  /**
+    Wave packet widths based on the Gaussian approximation
+
+    Options:
+     MATRIX(ndof, ntraj) 
+  */
+  MATRIX* wp_width;
 
   /**
     Quantum momenta defined as (-1) * \nabla_nuc |\chi| / |\chi|
@@ -441,6 +449,13 @@ class dyn_variables{
   vector<double> tcnbra_ekin;
 
 
+  ///================= Misc ===================
+  /**
+    The current MD time step
+  */
+  int timestep; 
+
+
 
   ///====================== In dyn_variables.cpp =====================
 
@@ -476,6 +491,7 @@ class dyn_variables{
   MATRIX get_coords(){ return *q; }
   MATRIX get_momenta(){ return *p; }
   MATRIX get_forces(){ return *f; }
+  MATRIX get_wp_width(){ return *wp_width; }
   MATRIX get_p_quant(){ return *p_quant; }
   MATRIX get_VP(){ return *VP; }
   MATRIX get_f_xf(){ return *f_xf; }
@@ -483,7 +499,14 @@ class dyn_variables{
   MATRIX get_momenta_aux(int i){ return *p_aux[i]; }
   MATRIX get_nab_phase(int i){ return *nab_phase[i]; }
   
-
+  void get_current_timestep(bp::dict params){
+    std::string key;
+    for(int i=0;i<len(params.values());i++){
+      key = bp::extract<std::string>(params.keys()[i]);
+      if(key=="timestep") { timestep = bp::extract<int>(params.values()[i]); }
+      else {continue;}
+    }
+  }
   
 
 

--- a/src/dyn/dyn_variables.h
+++ b/src/dyn/dyn_variables.h
@@ -340,6 +340,22 @@ class dyn_variables{
      vector< vector<int> > is_first(ntraj, nadi)
   */
   vector<vector<int>> is_first;
+  
+  /**
+    Whether to fix an auxiliary trajectory
+
+    Options:
+     vector< vector<int> > is_fixed(ntraj, nadi)
+  */
+  vector<vector<int>> is_fixed;
+  
+  /**
+    Whether to keep the auxiliary momenta
+
+    Options:
+     vector< vector<int> > is_keep(ntraj, nadi)
+  */
+  vector<vector<int>> is_keep;
 
   /**
     Nuclear coordinates of state-wise auxiliary trajectories

--- a/src/dyn/libdyn.cpp
+++ b/src/dyn/libdyn.cpp
@@ -247,6 +247,7 @@ void export_dyn_variables_objects(){
       .def("get_coords", &dyn_variables::get_coords)
       .def("get_momenta", &dyn_variables::get_momenta)
       .def("get_forces", &dyn_variables::get_forces)
+      .def("get_wp_width", &dyn_variables::get_wp_width)
       .def("get_p_quant", &dyn_variables::get_p_quant)
       .def("get_VP", &dyn_variables::get_VP)
       .def("get_f_xf", &dyn_variables::get_f_xf)

--- a/src/dyn/libdyn.cpp
+++ b/src/dyn/libdyn.cpp
@@ -105,6 +105,7 @@ void export_dyn_control_params_objects(){
       .def_readwrite("coherence_threshold", &dyn_control_params::coherence_threshold)
       .def_readwrite("use_xf_force", &dyn_control_params::use_xf_force)
       .def_readwrite("project_out_aux", &dyn_control_params::project_out_aux)
+      .def_readwrite("tp_algo", &dyn_control_params::tp_algo)
 
       ///================= Entanglement of trajectories ================================
       .def_readwrite("entanglement_opt", &dyn_control_params::entanglement_opt)

--- a/src/dyn/libdyn.cpp
+++ b/src/dyn/libdyn.cpp
@@ -103,6 +103,7 @@ void export_dyn_control_params_objects(){
       .def_readwrite("ave_gaps", &dyn_control_params::ave_gaps)
       .def_readwrite("wp_width", &dyn_control_params::wp_width)
       .def_readwrite("coherence_threshold", &dyn_control_params::coherence_threshold)
+      .def_readwrite("e_mask", &dyn_control_params::e_mask)
       .def_readwrite("use_xf_force", &dyn_control_params::use_xf_force)
       .def_readwrite("project_out_aux", &dyn_control_params::project_out_aux)
       .def_readwrite("tp_algo", &dyn_control_params::tp_algo)

--- a/src/dyn/wfcgrid2/Wfcgrid2.h
+++ b/src/dyn/wfcgrid2/Wfcgrid2.h
@@ -223,6 +223,8 @@ public:
 
   MATRIX get_pops(int rep);
   MATRIX get_pops(int rep, vector<double>& bmin, vector<double>& bmax);
+  
+  MATRIX get_coherences(int rep);
 
   void compute_wfc_gradients(int rep, int idof, double mass);
 

--- a/src/dyn/wfcgrid2/Wfcgrid2_properties.cpp
+++ b/src/dyn/wfcgrid2/Wfcgrid2_properties.cpp
@@ -423,6 +423,65 @@ MATRIX Wfcgrid2::get_pops(int rep, vector<double>& bmin, vector<double>& bmax){
 }
 
 
+MATRIX Wfcgrid2::get_coherences(int rep){
+/**
+  Compute the coherence indicator between all states in a given representation
+
+  Out:  MATRIX(nstates, nstates)
+  
+*/
+  MATRIX res(nstates, nstates);  
+  
+  int istate, jstate, npt1;
+  
+  MATRIX temp(Npts, 1);
+  if(rep=0){
+    for(npt1=0; npt1<Npts; npt1++){
+      temp.set(npt1, 0, (PSI_dia[npt1].H()*PSI_dia[npt1]).get(0,0).real() );
+    }
+  }
+  else if(rep=1){
+    for(npt1=0; npt1<Npts; npt1++){
+      temp.set(npt1, 0, (PSI_adi[npt1].H()*PSI_adi[npt1]).get(0,0).real() );
+    }
+  }
+  
+  double rho_i, rho_j, coh_ij;
+  if(rep=0){
+    for(npt1=0; npt1<Npts; npt1++){
+      for(istate=0; istate<nstates; istate++){
+        rho_i = (PSI_dia[npt1].get(istate, 0) * std::conj(PSI_dia[npt1].get(istate, 0))).real();
+        for(jstate=0; jstate<nstates; jstate++){  
+          rho_j = (PSI_dia[npt1].get(jstate, 0) * std::conj(PSI_dia[npt1].get(jstate, 0))).real();
+          coh_ij = rho_i*rho_j/temp.get(npt1,0);
+          res.add(istate, jstate, coh_ij);
+        }// for jstate
+      }// for istate
+    }// for npt1
+  }
+  else if(rep=1){
+    for(npt1=0; npt1<Npts; npt1++){
+      for(istate=0; istate<nstates; istate++){
+        rho_i = (PSI_adi[npt1].get(istate, 0) * std::conj(PSI_adi[npt1].get(istate, 0))).real();
+        for(jstate=0; jstate<nstates; jstate++){  
+          rho_j = (PSI_adi[npt1].get(jstate, 0) * std::conj(PSI_adi[npt1].get(jstate, 0))).real();
+          coh_ij = rho_i*rho_j/temp.get(npt1,0);
+          res.add(istate, jstate, coh_ij);
+        }// for jstate
+      }// for istate
+    }// for npt1
+  }
+
+  double dV = 1.0;
+  for(int idof=0; idof<ndof; idof++){  dV *= dr[idof];  }
+
+  res *= dV;
+
+  return res;
+
+}
+
+
 void Wfcgrid2::compute_wfc_gradients(int rep, int idof, double mass){
 // Compute wfc derivatives: first compute them in the k-space, then 
 // FT to the real space

--- a/src/dyn/wfcgrid2/libwfcgrid2.cpp
+++ b/src/dyn/wfcgrid2/libwfcgrid2.cpp
@@ -90,6 +90,9 @@ void export_Wfcgrid2_objects(){
   MATRIX (Wfcgrid2::*expt_get_pops_v2)
   (int rep, vector<double>& bmin, vector<double>& bmax) = &Wfcgrid2::get_pops;
 
+  MATRIX (Wfcgrid2::*expt_get_coherences_v1)
+  (int rep) = &Wfcgrid2::get_coherences;
+
 
 
   // Auxiliary functions
@@ -217,6 +220,7 @@ void export_Wfcgrid2_objects(){
       .def("get_den_mat", &Wfcgrid2::get_den_mat)
       .def("get_pops", expt_get_pops_v1)
       .def("get_pops", expt_get_pops_v2)
+      .def("get_coherences", expt_get_coherences_v1)
 
       /**  Wfcgrid2_SOFT    */
       .def("update_propagator_H", &Wfcgrid2::update_propagator_H)

--- a/src/libra_py/dynamics/exact/save.py
+++ b/src/libra_py/dynamics/exact/save.py
@@ -129,6 +129,12 @@ def exact_init_hdf5(saver, hdf5_output_level, _nsteps, _ndof, _nstates, _ngrid):
 
         # Density matrix computed in adiabatic rep
         saver.add_dataset("denmat_adi", (_nsteps, _nstates, _nstates), "C") 
+        
+        # Density matrix computed in adiabatic rep
+        saver.add_dataset("coherence_dia", (_nsteps, _nstates, _nstates), "R") 
+        
+        # Density matrix computed in adiabatic rep
+        saver.add_dataset("coherence_adi", (_nsteps, _nstates, _nstates), "R") 
 
 
     if hdf5_output_level>=4:
@@ -201,6 +207,8 @@ def save_data_hdf5(step, wfc, saver, params):
     if hdf5_output_level>=3:                
         saver.save_matrix(step, "denmat_dia", wfc.get_den_mat(0) ) 
         saver.save_matrix(step, "denmat_adi", wfc.get_den_mat(1) ) 
+        saver.save_matrix(step, "coherence_dia", wfc.get_coherences(0) ) 
+        saver.save_matrix(step, "coherence_adi", wfc.get_coherences(1) ) 
         
         
     if hdf5_output_level>=4:                

--- a/src/libra_py/dynamics/tsh/compute.py
+++ b/src/libra_py/dynamics/tsh/compute.py
@@ -322,6 +322,12 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
             * **dyn_params["project_out_aux"]** (int): Whether to project out the density on an auxiliary trajectory when its motion is classically forbidden. [ default: 0]
                 Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
+            * **dyn_params["tp_algo"]** (int): Turning-point algorithm for auxiliary trajectories
+
+               - 0: no treatment of a turning point
+               - 1: fix auxiliary trajectories of adiabatic states other than the active state [default]
+               - 2: collapse to the active state
+
             ///===============================================================================
             ///================= Entanglement of trajectories ================================
             ///===============================================================================
@@ -535,7 +541,7 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                              "ave_gaps":MATRIX(nstates,nstates),
                              "schwartz_decoherence_inv_alpha": MATRIX(nstates, 1),
                              "wp_width":0.3, "coherence_threshold":0.01, "use_xf_force": 0,
-                             "project_out_aux": 0
+                             "project_out_aux": 0, "tp_algo": 1
                            } )
 
     #================= Entanglement of trajectories ================================

--- a/src/libra_py/dynamics/tsh/compute.py
+++ b/src/libra_py/dynamics/tsh/compute.py
@@ -325,8 +325,9 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
             * **dyn_params["tp_algo"]** (int): Turning-point algorithm for auxiliary trajectories
 
                - 0: no treatment of a turning point
-               - 1: fix auxiliary trajectories of adiabatic states other than the active state [default]
-               - 2: collapse to the active state
+               - 1: collapse to the active state [default]
+               - 2: fix auxiliary positions of adiabatic states except for the active state
+               - 3: keep auxiliary momenta of adiabatic states except for the active state
 
             ///===============================================================================
             ///================= Entanglement of trajectories ================================

--- a/src/libra_py/dynamics/tsh/compute.py
+++ b/src/libra_py/dynamics/tsh/compute.py
@@ -306,6 +306,11 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
 
 
             * **dyn_params["wp_width"]** ( double ): A width of a Gaussian function as an approximation to adiabatic wave packets. [ default: 0.3 Bohr ]
+                This value is used for the initial conditions when the td Gaussian approximation is used, that is, use_td_width == 1
+                Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
+
+
+            * **dyn_params["wp_v"]** ( double ): The velocity of Gaussian wave packet following potential-free td Gaussian [ default: 0.0 a.u. ]
                 Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
 
@@ -313,7 +318,7 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                 Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
 
-            * **dyn_params["e_mask"]** ( double ): The masking parameter for computing nabla phase vectors. [ default: 0.0001 ]
+            * **dyn_params["e_mask"]** ( double ): The masking parameter for computing nabla phase vectors. [ default: 0.0001 Ha ]
                 Only used with the MQCXF method, that is, `decoherence_algo == 5`
 
 
@@ -323,15 +328,26 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                 - 0: Only Ehrenfest-like force; EhXF [ default ]
                 - 1: The whole force including the XF-correction; MQCXF 
             
+
             * **dyn_params["project_out_aux"]** (int): Whether to project out the density on an auxiliary trajectory when its motion is classically forbidden. [ default: 0]
                 Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
+
             * **dyn_params["tp_algo"]** (int): Turning-point algorithm for auxiliary trajectories
+                Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
                - 0: no treatment of a turning point
                - 1: collapse to the active state [default]
                - 2: fix auxiliary positions of adiabatic states except for the active state
                - 3: keep auxiliary momenta of adiabatic states except for the active state
+
+
+            * **dyn_params["use_td_width"]** (int): Whether to use the td Gaussian width for the nuclear wave packet approximation [ default : 0 ]
+                This option can be considered when it comes to unbounded systems.
+                This approximation is based on a nuclear wave packet on a free surface:
+                  \sigma_x(t)=\sqrt[\sigma_x(0)^2 + (wp_v * t)^2] 
+                Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
+
 
             ///===============================================================================
             ///================= Entanglement of trajectories ================================
@@ -545,8 +561,8 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                              "decoherence_rates":MATRIX(nstates, nstates),
                              "ave_gaps":MATRIX(nstates,nstates),
                              "schwartz_decoherence_inv_alpha": MATRIX(nstates, 1),
-                             "wp_width":0.3, "coherence_threshold":0.01, "e_mask": 0.0001,
-                             "use_xf_force": 0, "project_out_aux": 0, "tp_algo": 1
+                             "wp_width":0.3, "wp_v":0, "coherence_threshold":0.01, "e_mask": 0.0001,
+                             "use_xf_force": 0, "project_out_aux": 0, "tp_algo": 1, "use_td_width": 0
                            } )
 
     #================= Entanglement of trajectories ================================

--- a/src/libra_py/dynamics/tsh/compute.py
+++ b/src/libra_py/dynamics/tsh/compute.py
@@ -305,12 +305,12 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                 E_ij = <|E_i - E_j|>.  It is needed when dephasing_informed option is used
 
 
-            * **dyn_params["wp_width"]** ( double ): A width of a Gaussian function as an approximation to adiabatic wave packets. [ default: 0.3 Bohr ]
+            * **dyn_params["wp_width"]** ( MATRIX(ndof, 1) ): A width of a Gaussian function as an approximation to adiabatic wave packets.
                 This value is used for the initial conditions when the td Gaussian approximation is used, that is, use_td_width == 1
                 Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
 
-            * **dyn_params["wp_v"]** ( double ): The velocity of Gaussian wave packet following potential-free td Gaussian [ default: 0.0 a.u. ]
+            * **dyn_params["wp_v"]** ( MATRIX(ndof,1) ): The velocity of Gaussian wave packet following potential-free td Gaussian
                 Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
 
@@ -561,7 +561,7 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                              "decoherence_rates":MATRIX(nstates, nstates),
                              "ave_gaps":MATRIX(nstates,nstates),
                              "schwartz_decoherence_inv_alpha": MATRIX(nstates, 1),
-                             "wp_width":0.3, "wp_v":0, "coherence_threshold":0.01, "e_mask": 0.0001,
+                             "wp_width":MATRIX(dyn_var.ndof, 1), "wp_v":MATRIX(dyn_var.ndof, 1), "coherence_threshold":0.01, "e_mask": 0.0001,
                              "use_xf_force": 0, "project_out_aux": 0, "tp_algo": 1, "use_td_width": 0
                            } )
 

--- a/src/libra_py/dynamics/tsh/compute.py
+++ b/src/libra_py/dynamics/tsh/compute.py
@@ -313,6 +313,10 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                 Only used with independent-trajectory XF methods, that is, `decoherence_algo == 5 or 6`
 
 
+            * **dyn_params["e_mask"]** ( double ): The masking parameter for computing nabla phase vectors. [ default: 0.0001 ]
+                Only used with the MQCXF method, that is, `decoherence_algo == 5`
+
+
             * **dyn_params["use_xf_force"]** (int): Whether to use the XF-based force.
                 Only used with `decoherence_algo == 6`
                 
@@ -541,8 +545,8 @@ def run_dynamics(dyn_var, _dyn_params, ham, compute_model, _model_params, rnd):
                              "decoherence_rates":MATRIX(nstates, nstates),
                              "ave_gaps":MATRIX(nstates,nstates),
                              "schwartz_decoherence_inv_alpha": MATRIX(nstates, 1),
-                             "wp_width":0.3, "coherence_threshold":0.01, "use_xf_force": 0,
-                             "project_out_aux": 0, "tp_algo": 1
+                             "wp_width":0.3, "coherence_threshold":0.01, "e_mask": 0.0001,
+                             "use_xf_force": 0, "project_out_aux": 0, "tp_algo": 1
                            } )
 
     #================= Entanglement of trajectories ================================

--- a/src/libra_py/dynamics/tsh/save.py
+++ b/src/libra_py/dynamics/tsh/save.py
@@ -182,6 +182,10 @@ def init_tsh_data(saver, output_level, _nsteps, _ntraj, _ndof, _nadi, _ndia):
         # Trajectory-resolved diabatic TD-SE amplitudes
         if "Cdia" in saver.keywords: # and "Cdia" in saver.np_data.keys():
             saver.add_dataset("Cdia", (_nsteps, _ntraj, _ndia), "C") 
+        
+        # Trajectory-resolved quantum momenta
+        if "wp_width" in saver.keywords: # and "p_quant" in saver.np_data.keys():
+            saver.add_dataset("wp_width", (_nsteps, _ntraj, _ndof), "R") 
 
         # Trajectory-resolved quantum momenta
         if "p_quant" in saver.keywords: # and "p_quant" in saver.np_data.keys():
@@ -622,6 +626,12 @@ def save_hdf5_3D_new(saver, i, dyn_var, txt_type=0):
     if "Cdia" in saver.keywords and "Cdia" in saver.np_data.keys():
         Cdia = dyn_var.get_ampl_dia()
         saver.save_matrix(t, "Cdia", Cdia.T()) 
+    
+    # Wavepacket width
+    # Format: saver.add_dataset("wp_width", (_nsteps, _ntraj, _dof), "R")
+    if "wp_width" in saver.keywords and "wp_width" in saver.np_data.keys():
+        wp_width = dyn_var.get_wp_width()
+        saver.save_matrix(t, "wp_width", wp_width.T())
 
     # Trajectory-resolved quantum momenta
     # Format: saver.add_dataset("p_quant", (_nsteps, _ntraj, _dof), "R")


### PR DESCRIPTION
- Add the turning-point option parameter (off/collapse/fixing q_aux/keep p_aux)
- Make the masking constant (preventing diverging nab_phase vectors) to one of parameters
- Organize the XF electronic propagation
- Add a crude td wave packet width functionality
- Add a function to compute the coherence indicator in the exact calculation