### PR TITLE
Added an auxiliary function to step 3 for generating new active spaces based on the number of occupied and unoccupied orbitals

### DIFF
--- a/src/libra_py/workflows/nbra/step3.py
+++ b/src/libra_py/workflows/nbra/step3.py
@@ -949,7 +949,8 @@ def limit_active_space(params):
             lowest_orbital (integer): The lowest_orbital defined in step 2
             highest_orbital (integer): The highest_orbital defined in step 2
     Returns:
-        None but it prints the new value of lowest_orbital and highest_orbital 
+        l2 (integer): The new value of lowest_orbital 
+        h2 (integer): the new value of highest_orbital 
     """
     nocc = params['num_occ_orbitals']
     nunocc = params['num_unocc_orbitals']


### PR DESCRIPTION
After finding the proper number of occupied and unoccupied orbitals from the energy vs time plots, one requires to define new lowest_orbital and highest_orbital values for step 3 or rerun the step 2 from scratch using the new values of lowest_orbital and highest_orbital. By using the `step3.limit_active_space(params)` the user does not need to rerun step 2 nor writing a script to extract the data from step 2 calculations with the new active space for S, St, and E matrices. This function does all and the new tutorial works for many-body basis. 