### PR TITLE
Fix qtag_potential: two overloads with and without AA-BB-CC

### DIFF
--- a/src/dyn/qtag/libqtag.cpp
+++ b/src/dyn/qtag/libqtag.cpp
@@ -66,8 +66,13 @@ void export_qtag_objects(){
   CMATRIX (*expt_qtag_potential_v1)
   (MATRIX& q1, MATRIX& p1, MATRIX& s1, MATRIX& alp1, int n1, vector<int>& traj_on_surf_n1,
    MATRIX& q2, MATRIX& p2, MATRIX& s2, MATRIX& alp2, int n2, vector<int>& traj_on_surf_n2,
+   nHamiltonian& ham, int method, std::array<double,3> ABC) = &qtag_potential;
+  CMATRIX (*expt_qtag_potential_v1_noABC)
+  (MATRIX& q1, MATRIX& p1, MATRIX& s1, MATRIX& alp1, int n1, vector<int>& traj_on_surf_n1,
+   MATRIX& q2, MATRIX& p2, MATRIX& s2, MATRIX& alp2, int n2, vector<int>& traj_on_surf_n2,
    nHamiltonian& ham, int method) = &qtag_potential;
   def("qtag_potential", expt_qtag_potential_v1);
+  def("qtag_potential", expt_qtag_potential_v1_noABC);
 
 
   void (*expt_qtag_hamiltonian_and_overlap_v1)

--- a/src/dyn/qtag/qtag.cpp
+++ b/src/dyn/qtag/qtag.cpp
@@ -593,7 +593,20 @@ complex<double> BATe(int i, int j,
 
 CMATRIX qtag_potential(MATRIX& q1, MATRIX& p1, MATRIX& s1, MATRIX& alp1, int n1, vector<int>& traj_on_surf_n1,
                        MATRIX& q2, MATRIX& p2, MATRIX& s2, MATRIX& alp2, int n2, vector<int>& traj_on_surf_n2,
-                       nHamiltonian& ham, int method, double AA, double BB, double CC){
+                       nHamiltonian& ham, int method) {
+  return qtag_potential(q1, p1, s1, alp1, n1, traj_on_surf_n1,
+                        q2, p2, s2, alp2, n2, traj_on_surf_n2,
+                        ham, method, {0.0, 0.0, 0.0});
+}
+
+CMATRIX qtag_potential(MATRIX& q1, MATRIX& p1, MATRIX& s1, MATRIX& alp1, int n1, vector<int>& traj_on_surf_n1,
+                       MATRIX& q2, MATRIX& p2, MATRIX& s2, MATRIX& alp2, int n2, vector<int>& traj_on_surf_n2,
+                       nHamiltonian& ham, int method, std::array<double,3> ABC){
+
+  double AA = ABC[0];
+  double BB = ABC[1];
+  double CC = ABC[2];
+
 
   int ntraj_on_surf_n1 = q1.n_cols;
   int ntraj_on_surf_n2 = q2.n_cols;
@@ -785,7 +798,7 @@ void qtag_hamiltonian_and_overlap(MATRIX& q, MATRIX& p, MATRIX& alp, MATRIX& s, 
           CMATRIX h12(ntraj_on_surf_n1, ntraj_on_surf_n2);
           CMATRIX pot(ntraj_on_surf_n1, ntraj_on_surf_n2);
           
-          pot = qtag_potential(q1, p1, s1, a1, n1, traj_on_surf[n1], q2, p2, s2, a2, n2, traj_on_surf[n2], ham, method, AA, BB, CC);
+          pot = qtag_potential(q1, p1, s1, a1, n1, traj_on_surf[n1], q2, p2, s2, a2, n2, traj_on_surf[n2], ham, method, {AA, BB, CC});
           h12.dot_product(pot, s12);
           
 

--- a/src/dyn/qtag/qtag.h
+++ b/src/dyn/qtag/qtag.h
@@ -77,7 +77,10 @@ complex<double> LHAe(int i, int j,
 /// Elementary potential & coupling matrix
 CMATRIX qtag_potential(MATRIX& q1, MATRIX& p1, MATRIX& s1, MATRIX& alp1, int n1, vector<int>& traj_on_surf_n1,
                        MATRIX& q2, MATRIX& p2, MATRIX& s2, MATRIX& alp2, int n2, vector<int>& traj_on_surf_n2,
-                       nHamiltonian& ham, int method, double AA, double BB, double CC);
+                       nHamiltonian& ham, int method, std::array<double,3> ABC);
+CMATRIX qtag_potential(MATRIX& q1, MATRIX& p1, MATRIX& s1, MATRIX& alp1, int n1, vector<int>& traj_on_surf_n1,
+                       MATRIX& q2, MATRIX& p2, MATRIX& s2, MATRIX& alp2, int n2, vector<int>& traj_on_surf_n2,
+                       nHamiltonian& ham, int method);
 
 /// super-Hamiltonian and super-Overlap for all trajectories
 void qtag_hamiltonian_and_overlap(MATRIX& q, MATRIX& p, MATRIX& alp, MATRIX& s, CMATRIX& Coeff,

--- a/src/pch.h
+++ b/src/pch.h
@@ -19,6 +19,7 @@
 #include <ctime> 
 
 #include <complex>
+#include <array>
 #include <vector>
 
 #include <iomanip>


### PR DESCRIPTION
It saves python API as it was, but additionally supports all args of qtag_potential routines if they are needed