### PR TITLE
Updated Code: added kcrpmd auxiliary variable variables as double vector

### DIFF
--- a/src/dyn/dyn_variables.cpp
+++ b/src/dyn/dyn_variables.cpp
@@ -114,6 +114,9 @@ dyn_variables::dyn_variables(int _ndia, int _nadi, int _ndof, int _ntraj){
   ///================= QTSH ====================
   qtsh_vars_status = 0;
 
+  ///================= KC-RPMD ====================
+  kcrpmd_vars_status = 0;
+
 }
 
 
@@ -296,6 +299,18 @@ void dyn_variables::allocate_qtsh(){
   }
 }
 
+
+void dyn_variables::allocate_kcrpmd(){
+
+  if(kcrpmd_vars_status==0){
+    
+    auxiliary_y = vector<double>(1, -1.0);
+
+    kcrpmd_vars_status = 1;
+  }
+}// allocate_kcrpmd
+
+
 dyn_variables::dyn_variables(const dyn_variables& x){     
   //cout<<"dyn_variables copy constructor\n";
   int itraj, idof;
@@ -440,6 +455,16 @@ dyn_variables::dyn_variables(const dyn_variables& x){
     *qtsh_f_nc = *x.qtsh_f_nc;
 
   }// if QTSH vars
+
+
+  // KC-RPMD vars - only if initialized
+  if(x.kcrpmd_vars_status==1){
+    allocate_kcrpmd();
+    
+    // Copy content
+    auxiliary_y = x.auxiliary_y;
+
+  }// if KCRPMD vars
 
 }// dyn_variables cctor
 
@@ -590,6 +615,12 @@ dyn_variables::~dyn_variables(){
     delete qtsh_f_nc;
 
     qtsh_vars_status = 0;
+  }
+
+  if(kcrpmd_vars_status==1){
+    auxiliary_y.clear(); 
+
+    kcrpmd_vars_status = 0;
   }
 
 }

--- a/src/dyn/dyn_variables.h
+++ b/src/dyn/dyn_variables.h
@@ -509,6 +509,21 @@ class dyn_variables{
   MATRIX* qtsh_f_nc;
   
 
+  ///========= For kinetic-constrained RPMD ======================
+  /**
+    Status of the KC-RPMD vars
+
+    0 - not allocated;
+    1 - allocated
+  */
+  int kcrpmd_vars_status;
+  
+  /** 
+    The classical auxiliary electronic variable(s)
+  */ 
+  vector<double> auxiliary_y;
+
+
 
   ///================= Misc ===================
   /**
@@ -530,6 +545,7 @@ class dyn_variables{
   void allocate_tcnbra();
   void allocate_mqcxf();
   void allocate_qtsh();
+  void allocate_kcrpmd();
 
   dyn_variables(int _ndia, int _nadi, int _ndof, int _ntraj);
   dyn_variables(const dyn_variables& x); 


### PR DESCRIPTION
updated to current devel build and added new auxiliary variable for kcrpmd as vector<double>. Made sure to look at commit changes this time, only additions no deletions.