### PR TITLE
Revision of step 3 mapping function and printing of average decoherence rate

### DIFF
--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -1635,15 +1635,9 @@ void compute_dynamics(dyn_variables& dyn_var, bp::dict dyn_params,
   // Saves the current density matrix into the previous - needed for FSSH2 and GFSH (original)
   dyn_var.save_curr_dm_into_prev();
 
-  // Print out the average decoherence rates
-  // This is a temporary thong and will be removed after the assessment project...
-  //*dyn_var.ave_decoherence_rates;
   for(traj=0; traj<ntraj; traj++){
-    //cout << "============= For traj " << traj << endl;
-    //ave_dec_rate += decoherence_rates[traj].get(1,0);
     *dyn_var.ave_decoherence_rates += decoherence_rates[traj];
   }
-  //cout << "Average decoherence rate between states 0 and 1 is : " << ave_dec_rate/ntraj << endl;
   *dyn_var.ave_decoherence_rates /= ntraj;
 
 }

--- a/src/dyn/Dynamics.cpp
+++ b/src/dyn/Dynamics.cpp
@@ -1635,7 +1635,16 @@ void compute_dynamics(dyn_variables& dyn_var, bp::dict dyn_params,
   // Saves the current density matrix into the previous - needed for FSSH2 and GFSH (original)
   dyn_var.save_curr_dm_into_prev();
 
-  
+  // Print out the average decoherence rates
+  // This is a temporary thong and will be removed after the assessment project...
+  //*dyn_var.ave_decoherence_rates;
+  for(traj=0; traj<ntraj; traj++){
+    //cout << "============= For traj " << traj << endl;
+    //ave_dec_rate += decoherence_rates[traj].get(1,0);
+    *dyn_var.ave_decoherence_rates += decoherence_rates[traj];
+  }
+  //cout << "Average decoherence rate between states 0 and 1 is : " << ave_dec_rate/ntraj << endl;
+  *dyn_var.ave_decoherence_rates /= ntraj;
 
 }
 

--- a/src/dyn/dyn_decoherence_time.cpp
+++ b/src/dyn/dyn_decoherence_time.cpp
@@ -328,6 +328,7 @@ vector<MATRIX> schwartz_1(dyn_control_params& prms, CMATRIX& amplitudes, nHamilt
       double tau_inv2 = 0.0;
       for(int idof=0; idof<ndof; idof++){
         double dF = F_mf.get(idof, itraj) - F_st.get(idof, itraj);
+        //cout << "Flag schwartz_1 function for itraj " << itraj << " for i " << i << " and idof " << idof << " the F_mf is : " << F_mf << " and F_st is : " << F_st << endl;
         
         tau_inv2 += 0.25 * inv_alp.get(idof, 0) * dF * dF; 
       }
@@ -391,7 +392,7 @@ vector<MATRIX> schwartz_1(dyn_control_params& prms, CMATRIX& amplitudes, MATRIX&
       double tau_inv2 = 0.0;
       for(int idof=0; idof<ndof; idof++){
         double dF = F_mf.get(idof, itraj) - F_st.get(idof, itraj);
-        
+        //cout << "Flag schwartz_1 function for itraj " << itraj << " for i " << i << " and idof " << idof << " the F_mf is : " << F_mf << " and F_st is : " << F_st << endl;
         w2 = pow(w.get(idof,0), 2.0); 
         tau_inv2 += 0.25 * pow(4*M_PI/(w2*p.get(idof, itraj)), 2.0) * dF * dF; 
       }
@@ -450,6 +451,7 @@ vector<MATRIX> schwartz_2(dyn_control_params& prms, nHamiltonian& ham, MATRIX& i
         for(int idof=0; idof<ndof; idof++){
           double dF = F[i].get(idof, itraj) - F[j].get(idof, itraj);
         
+          //cout << "Flag schwartz_2 function for itraj " << itraj << " ij " << i << j << " and for idof " << idof << " the value of F[i].get(idof, itraj) is : " <<  F[i].get(idof, itraj) << " and F[i].get(idof, itraj) is : " <<  F[j].get(idof, itraj) << endl;
           tau_inv2 += 0.25 * inv_alp.get(idof, 0) * dF * dF; 
         }
         double tau_inv = sqrt(tau_inv2);
@@ -504,6 +506,7 @@ vector<MATRIX> Gu_Franco(dyn_control_params& prms, CMATRIX& amplitudes){
       for(int j=0;j<nstates; j++){
 
         double val = std::abs(loc_dm.get(i,j) ) * pref;
+        //cout << "Flag Gu-Franco function for itraj " << itraj << " ij " << i << j << ", std::abs(loc_dm.get(i,j) ) is : " <<  std::abs(loc_dm.get(i,j) ) << endl;
         res[itraj].set(i,j, val);
 
       }// for j states

--- a/src/dyn/dyn_decoherence_time.cpp
+++ b/src/dyn/dyn_decoherence_time.cpp
@@ -328,7 +328,6 @@ vector<MATRIX> schwartz_1(dyn_control_params& prms, CMATRIX& amplitudes, nHamilt
       double tau_inv2 = 0.0;
       for(int idof=0; idof<ndof; idof++){
         double dF = F_mf.get(idof, itraj) - F_st.get(idof, itraj);
-        //cout << "Flag schwartz_1 function for itraj " << itraj << " for i " << i << " and idof " << idof << " the F_mf is : " << F_mf << " and F_st is : " << F_st << endl;
         
         tau_inv2 += 0.25 * inv_alp.get(idof, 0) * dF * dF; 
       }
@@ -392,7 +391,6 @@ vector<MATRIX> schwartz_1(dyn_control_params& prms, CMATRIX& amplitudes, MATRIX&
       double tau_inv2 = 0.0;
       for(int idof=0; idof<ndof; idof++){
         double dF = F_mf.get(idof, itraj) - F_st.get(idof, itraj);
-        //cout << "Flag schwartz_1 function for itraj " << itraj << " for i " << i << " and idof " << idof << " the F_mf is : " << F_mf << " and F_st is : " << F_st << endl;
         w2 = pow(w.get(idof,0), 2.0); 
         tau_inv2 += 0.25 * pow(4*M_PI/(w2*p.get(idof, itraj)), 2.0) * dF * dF; 
       }
@@ -451,7 +449,6 @@ vector<MATRIX> schwartz_2(dyn_control_params& prms, nHamiltonian& ham, MATRIX& i
         for(int idof=0; idof<ndof; idof++){
           double dF = F[i].get(idof, itraj) - F[j].get(idof, itraj);
         
-          //cout << "Flag schwartz_2 function for itraj " << itraj << " ij " << i << j << " and for idof " << idof << " the value of F[i].get(idof, itraj) is : " <<  F[i].get(idof, itraj) << " and F[i].get(idof, itraj) is : " <<  F[j].get(idof, itraj) << endl;
           tau_inv2 += 0.25 * inv_alp.get(idof, 0) * dF * dF; 
         }
         double tau_inv = sqrt(tau_inv2);
@@ -506,7 +503,6 @@ vector<MATRIX> Gu_Franco(dyn_control_params& prms, CMATRIX& amplitudes){
       for(int j=0;j<nstates; j++){
 
         double val = std::abs(loc_dm.get(i,j) ) * pref;
-        //cout << "Flag Gu-Franco function for itraj " << itraj << " ij " << i << j << ", std::abs(loc_dm.get(i,j) ) is : " <<  std::abs(loc_dm.get(i,j) ) << endl;
         res[itraj].set(i,j, val);
 
       }// for j states

--- a/src/dyn/dyn_variables.cpp
+++ b/src/dyn/dyn_variables.cpp
@@ -33,6 +33,7 @@ void dyn_variables::allocate_electronic_vars(){
     ampl_adi = new CMATRIX(nadi, ntraj);
     q_mm = new MATRIX(nadi, ntraj);
     p_mm = new MATRIX(nadi, ntraj);
+    ave_decoherence_rates = new MATRIX(nadi, nadi);
     proj_adi = vector<CMATRIX*>(ntraj);
     dm_dia = vector<CMATRIX*>(ntraj);
     dm_adi = vector<CMATRIX*>(ntraj);
@@ -348,6 +349,7 @@ dyn_variables::dyn_variables(const dyn_variables& x){
     *ampl_adi = *x.ampl_adi;
     *q_mm = *x.q_mm;
     *p_mm = *x.p_mm;
+    *ave_decoherence_rates = *x.ave_decoherence_rates;
     for(itraj=0; itraj<ntraj; itraj++){
       *proj_adi[itraj] = *x.proj_adi[itraj];
       *dm_dia[itraj] = *x.dm_dia[itraj];
@@ -524,6 +526,7 @@ dyn_variables::~dyn_variables(){
     delete ampl_adi;
     delete q_mm;
     delete p_mm;
+    delete ave_decoherence_rates;
 
     act_states.clear();
     act_states_dia.clear();

--- a/src/dyn/dyn_variables.h
+++ b/src/dyn/dyn_variables.h
@@ -576,6 +576,12 @@ class dyn_variables{
   */
   vector< vector< vector<double> > > coherence_factors;
 
+  ///====================== For average decoherence rates
+  /*
+    Stores the decoherence rates between states averaged over all trajectories
+  */
+
+  MATRIX* ave_decoherence_rates;
 
   ///====================== In dyn_variables.cpp =====================
 
@@ -628,6 +634,7 @@ class dyn_variables{
   MATRIX get_momenta_aux(int i){ return *p_aux[i]; }
   MATRIX get_nab_phase(int i){ return *nab_phase[i]; }
   MATRIX get_qtsh_f_nc(){ return *qtsh_f_nc; }
+  MATRIX get_ave_decoherence_rates(){ return *ave_decoherence_rates; }
   
   void get_current_timestep(bp::dict params){
     std::string key;

--- a/src/dyn/libdyn.cpp
+++ b/src/dyn/libdyn.cpp
@@ -272,6 +272,7 @@ void export_dyn_variables_objects(){
       .def("get_ampl_dia", &dyn_variables::get_ampl_dia)
       .def("get_q_mm", &dyn_variables::get_q_mm)
       .def("get_p_mm", &dyn_variables::get_p_mm)
+      .def("get_ave_decoherence_rates", &dyn_variables::get_ave_decoherence_rates)
       .def("get_proj_adi", &dyn_variables::get_proj_adi)
       .def("get_dm_adi", expt_get_dm_adi_v1)
       .def("get_dm_adi", expt_get_dm_adi_v2)

--- a/src/libra_py/dynamics/tsh/save.py
+++ b/src/libra_py/dynamics/tsh/save.py
@@ -239,7 +239,7 @@ def init_tsh_data(saver, output_level, _nsteps, _ntraj, _ndof, _nadi, _ndia):
         if "qtsh_f_nc" in saver.keywords:  # and "f_xf" in saver.np_data.keys():
             saver.add_dataset("qtsh_f_nc", (_nsteps, _ntraj, _ndof), "R")
 
-        # Trajectory-resolved decoherence time
+        # Trajectory-resolved decoherence rates
         if "ave_decoherence_rates" in saver.keywords:  # decoherence time:
             saver.add_dataset("ave_decoherence_rates", (_nsteps, _nadi, _nadi), "R") 
 
@@ -759,7 +759,7 @@ def save_hdf5_3D_new(saver, i, dyn_var, txt_type=0):
         qtsh_f_nc = dyn_var.get_qtsh_f_nc()
         saver.save_matrix(t, "qtsh_f_nc", qtsh_f_nc.T())
 
-    # Average decoherence time
+    # Average decoherence rate
     # Format: saver.add_dataset("ave_decoherence_rates", (_nsteps, _nadi, _nadi), "R") 
     if "ave_decoherence_rates" in saver.keywords and "ave_decoherence_rates" in saver.np_data.keys():
         ave_decoherence_rates = dyn_var.get_ave_decoherence_rates()

--- a/src/libra_py/dynamics/tsh/save.py
+++ b/src/libra_py/dynamics/tsh/save.py
@@ -239,6 +239,10 @@ def init_tsh_data(saver, output_level, _nsteps, _ntraj, _ndof, _nadi, _ndia):
         if "qtsh_f_nc" in saver.keywords:  # and "f_xf" in saver.np_data.keys():
             saver.add_dataset("qtsh_f_nc", (_nsteps, _ntraj, _ndof), "R")
 
+        # Trajectory-resolved decoherence time
+        if "ave_decoherence_rates" in saver.keywords:  # decoherence time:
+            saver.add_dataset("ave_decoherence_rates", (_nsteps, _nadi, _nadi), "R") 
+
     if output_level >= 4:
 
         # Trajectory-resolved vibronic Hamiltoninans in the adiabatic representation
@@ -754,6 +758,12 @@ def save_hdf5_3D_new(saver, i, dyn_var, txt_type=0):
     if "qtsh_f_nc" in saver.keywords and "qtsh_f_nc" in saver.np_data.keys():
         qtsh_f_nc = dyn_var.get_qtsh_f_nc()
         saver.save_matrix(t, "qtsh_f_nc", qtsh_f_nc.T())
+
+    # Average decoherence time
+    # Format: saver.add_dataset("ave_decoherence_rates", (_nsteps, _nadi, _nadi), "R") 
+    if "ave_decoherence_rates" in saver.keywords and "ave_decoherence_rates" in saver.np_data.keys():
+        ave_decoherence_rates = dyn_var.get_ave_decoherence_rates()
+        saver.save_matrix(t, "ave_decoherence_rates", ave_decoherence_rates.T())
 
 
 def save_hdf5_4D(

--- a/src/libra_py/packages/cp2k/methods.py
+++ b/src/libra_py/packages/cp2k/methods.py
@@ -35,8 +35,8 @@ elif sys.platform == "linux" or sys.platform == "linux2":
     from liblibra_core import *
 import util.libutil as comn
 
-from libra_py import data_outs, data_stat
-from libra_py import units
+from libra_py import data_outs, data_stat, data_conv
+from libra_py import units, molden_methods
 
 
 def ndigits(integer_number: int):
@@ -2354,3 +2354,45 @@ def atom_components_cp2k(filename):
         index = list(np.where(atoms == i)[0])
         indices.append(index)
     return indices
+
+
+def compute_mo_overlap(params):
+    """
+    This function computes the molecular orbital overlap calculations between
+    two geometries: $\langle\Phi_{i,R}\|\Phi_{j,R'}\rangle$. It takes a dictionary as parameters.
+    Args:
+        params (dictionary):
+            molden_file_1 (string): The path to the first geometry molden file
+            molden_file_2 (string): The path to the second geometry molden file
+            is_spherical (bool): The spherical coordinate boolean flga
+            nprocs (integer): The number of pocessors
+    Returns:
+        mo_overlap_matrix (numpy array): The overlap between molecular orbitals
+    """
+    # Create Libint integral shells for each molden file
+    shell_1, l_vals_1 = molden_methods.molden_file_to_libint_shell(params['molden_file_1'], params['is_spherical'])
+    shell_2, l_vals_2 = molden_methods.molden_file_to_libint_shell(params['molden_file_2'], params['is_spherical'])
+    new_indices = resort_molog_eigenvectors(l_vals_1)
+    eig_vect_1, energies_1 = molden_methods.eigenvectors_molden(params['molden_file_1'], nbasis(shell_1), l_vals_1)
+    eig_vect_2, energies_2 = molden_methods.eigenvectors_molden(params['molden_file_2'], nbasis(shell_2), l_vals_2)
+    
+    # The new eigenvectors
+    resortted_eig_vect_1 = []
+    resortted_eig_vect_2 = []
+    for j in range(len(eig_vect_1)):
+        # the new and sorted eigenvector
+        eigenvector1 = eig_vect_1[j]
+        eigenvector1 = eigenvector1[new_indices]
+        eigenvector2 = eig_vect_2[j]
+        eigenvector2 = eigenvector2[new_indices]
+        # append it to the eigenvectors list
+        resortted_eig_vect_1.append(eigenvector1)
+        resortted_eig_vect_2.append(eigenvector2)
+    resortted_eig_vect_1 = np.array(resortted_eig_vect_1)
+    resortted_eig_vect_2 = np.array(resortted_eig_vect_2)
+    ao_matrix = compute_overlaps(shell_1, shell_2, params['nprocs'])
+    ao_matrix = data_conv.MATRIX2nparray(ao_matrix)
+    mo_overlap_matrix = np.linalg.multi_dot([resortted_eig_vect_1, ao_matrix, 
+                                             resortted_eig_vect_2.T])
+    return mo_overlap_matrix
+

--- a/src/libra_py/workflows/nbra/mapping.py
+++ b/src/libra_py/workflows/nbra/mapping.py
@@ -311,46 +311,6 @@ def num_of_perms(x):
     return cnt
 
 
-def count_inversions(arr):
-    """
-    Count the number of inversions in a list.
-    An inversion is a pair (i, j) such that i < j and arr[i] > arr[j].
-
-    Args:
-        arr (list[int]): A list of integers.
-
-    Returns:
-        int: Number of inversions (unordered pairs that are out of order).
-    """
-    def merge_sort(nums):
-        if len(nums) <= 1:
-            return nums, 0
-
-        mid = len(nums) // 2
-        left, inv_left = merge_sort(nums[:mid])
-        right, inv_right = merge_sort(nums[mid:])
-        merged, inv_split = merge(left, right)
-        return merged, inv_left + inv_right + inv_split
-
-    def merge(left, right):
-        result = []
-        i = j = inv_count = 0
-        while i < len(left) and j < len(right):
-            if left[i] <= right[j]:
-                result.append(left[i])
-                i += 1
-            else:
-                result.append(right[j])
-                j += 1
-                inv_count += len(left) - i  # Count inversions here
-        result.extend(left[i:])
-        result.extend(right[j:])
-        return result, inv_count
-
-    _, total_inversions = merge_sort(arr)
-    return total_inversions
-
-
 def ovlp_arb(SD1, SD2, S, use_minimal=False, user_notation=0):
     """Compute the overlap of two generic SDs: <SD1|SD2>
 
@@ -384,7 +344,7 @@ def ovlp_arb(SD1, SD2, S, use_minimal=False, user_notation=0):
     sd2 = sd2indx(SD2, nbasis, False, user_notation)
 
     # Compute the phase using the original determinants in the internal notation
-    phase = (-1)**(count_inversions(sd1) + count_inversions(sd2)) #(num_of_perms(sd1) + num_of_perms(sd2))
+    #phase = (-1)**(count_inversions(sd1) + count_inversions(sd2)) #(num_of_perms(sd1) + num_of_perms(sd2))
 
     # Now reduce the determinants for faster calculations
     if use_minimal:
@@ -485,7 +445,7 @@ def ovlp_arb_mo(SD1, SD2, S, user_notation=0):
 
     res = delta(Py2Cpp_int(sd1), Py2Cpp_int(sd2))
 
-    phase = (-1)**(count_inversions(sd1) + count_inversions(sd2)) #(num_of_perms(sd1) + num_of_perms(sd2))
+    #phase = (-1)**(count_inversions(sd1) + count_inversions(sd2)) #(num_of_perms(sd1) + num_of_perms(sd2))
 
     s = 0.0
     # The SDs are coupled
@@ -507,7 +467,7 @@ def ovlp_arb_mo(SD1, SD2, S, user_notation=0):
         s = det(x)
 
         # s = 1.0+0.0j
-    return s * phase
+    return s #* phase
 
 
 def ovlp_mat_arb(SD1, SD2, S, use_minimal=True, use_mo_approach=False, user_notation=0):

--- a/src/libra_py/workflows/nbra/mapping3.py
+++ b/src/libra_py/workflows/nbra/mapping3.py
@@ -21,6 +21,7 @@
 
 import os, sys, math
 import numpy as np
+from .mapping import sd2indx 
 
 # Fisrt, we add the location of the library to test to the PYTHON path
 if sys.platform == "cygwin":
@@ -29,10 +30,10 @@ elif sys.platform == "linux" or sys.platform == "linux2":
     from liblibra_core import *
 
 
-
 def ovlp_arb(_SD1, _SD2, S, active_space=None, verbose=False):
     """Compute the overlap of two generic SDs: <SD1|SD2>
-
+    This functions translates the explicit use of two Python `for` loops
+    into a more efficient way using numpy
     Args:
 
         _SD1 ( lists of ints ): first SD, such that:
@@ -41,7 +42,7 @@ def ovlp_arb(_SD1, _SD2, S, active_space=None, verbose=False):
         _SD2 ( lists of ints ): second SD, such that:
             SeeAlso: ```inp``` in the ```sd2indx(inp)``` function
 
-        S ( CMATRIX(N,N) ): is the matrix in the space of 1-el orbital
+        S ( numpy array(N,N) ): is the matrix in the space of 1-el orbital
 
         active_space ( list of ints ): indices of the orbitals (starting from 1) to 
             include into consideration. If None - all the orbitals will be used [ default: None ]
@@ -77,7 +78,95 @@ def ovlp_arb(_SD1, _SD2, S, active_space=None, verbose=False):
     # Apply the determinant formula
     det_size = len(SD1)
     s = np.zeros( (det_size, det_size), dtype=np.float64); 
+    """ Commented on 7/22/2025
+    # ============================== The numpy version of the above double-for-loops
+    # Find the tensor product of the SD1 and SD2
+    SD_tensor_product = np.tensordot(SD1, SD2, axes=0)
+    # Next, find the sign of these elementwise multiplications
+    SD_tensor_product_sign = np.sign(SD_tensor_product)
+    # Now, find where we have alpha-beta indices so that the 
+    negative_sign_indices = np.where(SD_tensor_product_sign < 0)
+    s[negative_sign_indices] = 0
+    """
+    # Let's build the matrix related to sd1 and sd2 from the KS orbitals
+    # For this, we reuire to turn each element into matrix indices
+    sd1 = sd2indx(SD1, nbasis, False, 0) # adopted from the `mapping` module
+    sd2 = sd2indx(SD2, nbasis, False, 0)
+    # What about beta indices?! We should add `nbasis/2` to them. This is added on 7/22/2025
+    # With this simple approach, there is no need for tensor product or the `if else` clause brought
+    # previously since the elements corresponding to the alpha-beta orbitals are already
+    # zero in the two-spinor format of the KS matrices :)
+    beta_indices = np.where(np.array(SD1) < 0)
+    sd1 = np.array(sd1)
+    sd1[beta_indices] += int(nbasis/2)
+
+    beta_indices = np.where(np.array(SD2) < 0)
+    sd2 = np.array(sd2)
+    sd2[beta_indices] += int(nbasis/2)
+
+
+    # Making the numpy array
+    s = S[sd1,:][:,sd2]
     
+    if verbose==True:
+        print(s)
+    res = np.linalg.det(s) #* phase
+
+    return res
+
+
+
+def ovlp_arb_2(_SD1, _SD2, S, active_space=None, verbose=False):
+    """Compute the overlap of two generic SDs: <SD1|SD2>
+    The difference of this function with the above one is that it uses explicitly
+    two Pythonic `for` loops which are not optimized for very large sets
+
+    Args:
+
+        _SD1 ( lists of ints ): first SD, such that:
+            SeeAlso: ```inp``` in the ```sd2indx(inp)``` function
+
+        _SD2 ( lists of ints ): second SD, such that:
+            SeeAlso: ```inp``` in the ```sd2indx(inp)``` function
+
+        S ( numpy array(N,N) ): is the matrix in the space of 1-el orbital
+
+        active_space ( list of ints ): indices of the orbitals (starting from 1) to 
+            include into consideration. If None - all the orbitals will be used [ default: None ]
+
+        verbose ( Bool ): whether to print some extra info [ default: False] 
+
+    Returns:
+        complex: the overlap of the two determinants <SD1|SD2>
+
+    """
+
+    nbasis = S.shape[0] #num_of_rows
+
+    SD1, SD2 = [], []
+
+    if active_space == None:
+        SD1, SD2 = _SD1, _SD2
+    else:
+        for a in _SD1:
+            if abs(a) in active_space:
+                SD1.append(a)
+        for a in _SD2:
+            if abs(a) in active_space:
+                SD2.append(a)
+
+    res = 0.0 + 0j
+    if len(SD1) != len(SD2):
+        print("Trying to compute an overlap of the SDs with different number of electrons")
+        print("Exiting...")
+        sys.exit(0)
+
+        
+    # Apply the determinant formula
+    det_size = len(SD1)
+    s = np.zeros( (det_size, det_size), dtype=np.float64); 
+    # ============================== The explicit version with for loops
+    # Note: It seems that this explicit vesion doesn't consider the unrestricted spin calculations
     # Forming the overlap of the SDs
     for indx_I, I in enumerate(SD1):
         for indx_J, J in enumerate(SD2):


### PR DESCRIPTION
* Revised step 3 `mapping3.py` module by including beta spin channel indices in the computation of the overlap of SDs with the main addition as:
```python
    beta_indices = np.where(np.array(SD1) < 0)
    sd1 = np.array(sd1)
    sd1[beta_indices] += int(nbasis/2)

    beta_indices = np.where(np.array(SD2) < 0)
    sd2 = np.array(sd2)
    sd2[beta_indices] += int(nbasis/2)
```
The step 3 calculations are all done with `mapping3.py` module (some cleaning may be required for removing or merging the mapping modules)
* Added a printing variable for average decoherence rate related to assessment project: `ave_decoherence_rates` in `save.py`
* Added an auxiliary function for computation of the molecular orbital overlaps between two `molden` files useful in ML mapping approach for computation of the time-overlaps (for non-periodic case)
* Tested the functionality of these commits and changes for the assessment project and also for the developer tutorial for computation of the overlaps